### PR TITLE
BigFloat NAN,+INF,-INF

### DIFF
--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java
@@ -242,13 +242,10 @@ public class BigDecimalMath {
 	 */
 	public static boolean isIntValue(BigDecimal value) {
 		// TODO impl isIntValue() without exceptions
-		try {
-			value.intValueExact();
-			return true;
-		} catch (ArithmeticException ex) {
-			// ignored
-		}
-		return false;
+
+		// @see BigDecimal#intValueExact()
+		long val = value.longValue();
+		return (int)val==val;
 	}
 
 	/**

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java
@@ -242,10 +242,13 @@ public class BigDecimalMath {
 	 */
 	public static boolean isIntValue(BigDecimal value) {
 		// TODO impl isIntValue() without exceptions
-
-		// @see BigDecimal#intValueExact()
-		long val = value.longValue();
-		return (int)val==val;
+		try {
+			value.intValueExact();
+			return true;
+		} catch (ArithmeticException ex) {
+			// ignored
+		}
+		return false;
 	}
 
 	/**

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
@@ -398,14 +398,15 @@ public class BigFloat implements Comparable<BigFloat> {
 	public BigFloat divide(BigFloat x) {
 		if (x.isSpecial())
 			return x;
-		if (this.isZero())
-			if (x.isZero())
+		if(this.isZero())
+			return ZERO;
+		if (x.isZero())
+			if (this.isZero())
 				return NaN; // 0 or -0 / 0 = NaN
-			else if(x.isNegative())
+			else if (this.isNegative())
 				return NEGATIVE_INFINITY;// -N / 0 = -INF
 			else return POSITIVE_INFINITY;// N / 0 = +INF
-		if(x.isZero())
-			return x.divide(this);
+		// 0 / N = 0
 		Context c = max(context, x.context);
 		return c.valueOf(value.divide(x.value, c.mathContext));
 	}

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
@@ -398,7 +398,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	public BigFloat divide(BigFloat x) {
 		if (x.isSpecial())
 			return x;
-		if(this.isZero())
+		if (this.isZero() && !x.isZero())
 			return ZERO;
 		if (x.isZero())
 			if (this.isZero())

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
@@ -185,6 +185,8 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(BigFloat x) {
+		if (x.isSpecial())
+			return x;
 		Context c = max(context, x.context);
 		return c.valueOf(value.add(x.value, c.mathContext));
 	}
@@ -253,6 +255,8 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(BigFloat x) {
+		if (x.isSpecial())
+			return x;
 		Context c = max(context, x.context);
 		return c.valueOf(value.subtract(x.value, c.mathContext));
 	}
@@ -321,6 +325,8 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(BigFloat x) {
+		if (x.isSpecial())
+			return x;
 		Context c = max(context, x.context);
 		return c.valueOf(value.multiply(x.value, c.mathContext));
 	}
@@ -391,7 +397,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 */
 	public BigFloat divide(BigFloat x) {
 		if (x.isSpecial())
-			return x.divide(this);
+			return x;
 		if (this.isZero())
 			if (x.isZero())
 				return NaN; // 0 or -0 / 0 = NaN
@@ -469,7 +475,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 */
 	public BigFloat remainder(BigFloat x) {
 		if (x.isSpecial())
-			return x.remainder(this);
+			return x;
 		Context c = max(context, x.context);
 		return c.valueOf(value.remainder(x.value, c.mathContext));
 	}
@@ -539,7 +545,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 */
 	public BigFloat pow(BigFloat y) {
 		if (y.isSpecial())
-			return y.pow(this);
+			return y;
 		Context c = max(context, y.context);
 		return c.valueOf(BigDecimalMath.pow(this.value, y.value, c.mathContext));
 	}
@@ -609,7 +615,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 */
 	public BigFloat root(BigFloat y) {
 		if (y.isSpecial())
-			return y.root(this);
+			return y;
 		Context c = max(context, y.context);
 		return c.valueOf(BigDecimalMath.root(this.value, y.value, c.mathContext));
 	}
@@ -967,7 +973,7 @@ public class BigFloat implements Comparable<BigFloat> {
 			return ifNotNaN;
 		}
 
-		private BigFloat unsupported() {
+		private void unsupported() {
 			throw new NumberFormatException(this.toString());
 		}
 
@@ -1224,12 +1230,12 @@ public class BigFloat implements Comparable<BigFloat> {
 
 		@Override
 		public BigFloat getIntegralPart() {
-			return unsupported();
+			return this;
 		}
 
 		@Override
 		public BigFloat getFractionalPart() {
-			return unsupported();
+			return this;
 		}
 
 		@Override
@@ -1594,6 +1600,10 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimalMath#log(BigDecimal, MathContext)
 	 */
 	public static BigFloat log(BigFloat x) {
+		if (x.isSpecial())
+			return x;
+		if(x.isZero())
+			return NEGATIVE_INFINITY;
 		return x.context.valueOf(BigDecimalMath.log(x.value, x.context.mathContext));
 	}
 
@@ -1646,6 +1656,8 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimalMath#sqrt(BigDecimal, MathContext)
 	 */
 	public static BigFloat sqrt(BigFloat x) {
+		if(x.isEqual(NEGATIVE_ONE))
+			return NaN;
 		return x.context.valueOf(BigDecimalMath.sqrt(x.value, x.context.mathContext));
 	}
 

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
@@ -5,7 +5,7 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Objects;
 
-import static ch.obermuhlner.math.big.BigFloat.SpecialBigFloat.*;
+import static ch.obermuhlner.math.big.BigFloat.SpecialBigFloat.TYPE;
 
 /**
  * A wrapper around {@link BigDecimal} which simplifies the consistent usage of the {@link MathContext}
@@ -18,80 +18,80 @@ import static ch.obermuhlner.math.big.BigFloat.SpecialBigFloat.*;
  * <p>The API for calculations is simplified and more consistent with the typical mathematical usage.</p>
  * <ul>
  * <li>Factory methods for values:
- *   <ul>
- *   <li><code>valueOf(BigFloat)</code></li>
- *   <li><code>valueOf(BigDecimal)</code></li>
- *   <li><code>valueOf(int)</code></li>
- *   <li><code>valueOf(long)</code></li>
- *   <li><code>valueOf(double)</code></li>
- *   <li><code>valueOf(String)</code></li>
- *   <li><code>pi()</code></li>
- *   <li><code>e()</code></li>
- *   </ul>
+ * <ul>
+ * <li><code>valueOf(BigFloat)</code></li>
+ * <li><code>valueOf(BigDecimal)</code></li>
+ * <li><code>valueOf(int)</code></li>
+ * <li><code>valueOf(long)</code></li>
+ * <li><code>valueOf(double)</code></li>
+ * <li><code>valueOf(String)</code></li>
+ * <li><code>pi()</code></li>
+ * <li><code>e()</code></li>
+ * </ul>
  * </li>
  * <li>All standard operators:
- *   <ul>
- *   <li><code>add(x)</code></li>
- *   <li><code>subtract(x)</code></li>
- *   <li><code>multiply(x)</code></li>
- *   <li><code>remainder(x)</code></li>
- *   <li><code>pow(y)</code></li>
- *   <li><code>root(y)</code></li>
- *   </ul>
+ * <ul>
+ * <li><code>add(x)</code></li>
+ * <li><code>subtract(x)</code></li>
+ * <li><code>multiply(x)</code></li>
+ * <li><code>remainder(x)</code></li>
+ * <li><code>pow(y)</code></li>
+ * <li><code>root(y)</code></li>
+ * </ul>
  * </li>
  * <li>Calculation methods are overloaded for different value types:
- *   <ul>
- *   <li><code>add(BigFloat)</code></li>
- *   <li><code>add(BigDecimal)</code></li>
- *   <li><code>add(int)</code></li>
- *   <li><code>add(long)</code></li>
- *   <li><code>add(double)</code></li>
- *   <li>...</li>
- *   </ul>
+ * <ul>
+ * <li><code>add(BigFloat)</code></li>
+ * <li><code>add(BigDecimal)</code></li>
+ * <li><code>add(int)</code></li>
+ * <li><code>add(long)</code></li>
+ * <li><code>add(double)</code></li>
+ * <li>...</li>
+ * </ul>
  * </li>
  * <li>Mathematical functions are written as they are traditionally are written:
- *   <ul>
- *   <li><code>abs(x)</code></li>
- *   <li><code>log(x)</code></li>
- *   <li><code>sin(x)</code></li>
- *   <li><code>min(x1, x2, ...)</code></li>
- *   <li><code>max(x1, x2, ...)</code></li>
- *   <li>...</li>
- *   </ul>
+ * <ul>
+ * <li><code>abs(x)</code></li>
+ * <li><code>log(x)</code></li>
+ * <li><code>sin(x)</code></li>
+ * <li><code>min(x1, x2, ...)</code></li>
+ * <li><code>max(x1, x2, ...)</code></li>
+ * <li>...</li>
+ * </ul>
  * </li>
  * <li>Support for advanced mathematical functions:
- *   <ul>
- *   <li><code>sqrt(x)</code></li>
- *   <li><code>log(x)</code></li>
- *   <li><code>exp(x)</code></li>
- *   <li><code>sin(x)</code></li>
- *   <li><code>cos(x)</code></li>
- *   <li><code>tan(x)</code></li>
- *   <li>...</li>
- *   </ul>
+ * <ul>
+ * <li><code>sqrt(x)</code></li>
+ * <li><code>log(x)</code></li>
+ * <li><code>exp(x)</code></li>
+ * <li><code>sin(x)</code></li>
+ * <li><code>cos(x)</code></li>
+ * <li><code>tan(x)</code></li>
+ * <li>...</li>
+ * </ul>
  * </li>
  * <li>Methods to access parts of a value:
- *   <ul>
- *   <li><code>getMantissa()</code></li>
- *   <li><code>getExponent()</code></li>
- *   <li><code>getIntegralPart()</code></li>
- *   <li><code>getFractionalPart()</code></li>
- *   </ul>
+ * <ul>
+ * <li><code>getMantissa()</code></li>
+ * <li><code>getExponent()</code></li>
+ * <li><code>getIntegralPart()</code></li>
+ * <li><code>getFractionalPart()</code></li>
+ * </ul>
  * </li>
  * <li>Equals and Hashcode methods:
- *   <ul>
- *   <li><code>equals(Object)</code> that returns whether two <code>BigFloat</code> values are mathematically the same</li>
- *   <li><code>hashCode()</code> consistent with <code>equals(Object)</code></li>
- *   </ul>
+ * <ul>
+ * <li><code>equals(Object)</code> that returns whether two <code>BigFloat</code> values are mathematically the same</li>
+ * <li><code>hashCode()</code> consistent with <code>equals(Object)</code></li>
+ * </ul>
  * </li>
  * <li>Comparison methods:
- *   <ul>
- *   <li><code>isEqual(BigFloat)</code></li>
- *   <li><code>isLessThan(BigFloat)</code></li>
- *   <li><code>isLessThanOrEqual(BigFloat)</code></li>
- *   <li><code>isGreaterThan(BigFloat)</code></li>
- *   <li><code>isGreaterThanOrEqual(BigFloat)</code></li>
- *   </ul>
+ * <ul>
+ * <li><code>isEqual(BigFloat)</code></li>
+ * <li><code>isLessThan(BigFloat)</code></li>
+ * <li><code>isLessThanOrEqual(BigFloat)</code></li>
+ * <li><code>isGreaterThan(BigFloat)</code></li>
+ * <li><code>isGreaterThanOrEqual(BigFloat)</code></li>
+ * </ul>
  * </li>
  * </ul>
  *
@@ -99,195 +99,39 @@ import static ch.obermuhlner.math.big.BigFloat.SpecialBigFloat.*;
  *
  * <p>Before doing any calculations you need to create a <code>Context</code> specifying the precision used for all calculations.</p>
  * <pre>
-Context context = BigFloat.context(100); // precision of 100 digits
-Context anotherContext = BigFloat.context(new MathContext(10, RoundingMode.HALF_UP); // precision of 10 digits, rounding half up
-</pre>
+ * Context context = BigFloat.context(100); // precision of 100 digits
+ * Context anotherContext = BigFloat.context(new MathContext(10, RoundingMode.HALF_UP); // precision of 10 digits, rounding half up
+ * </pre>
  *
  * <p>The <code>Context</code> can then be used to create the first value of the calculation:</p>
  * <pre>
-BigFloat value1 = context.valueOf(640320);
-</pre>
+ * BigFloat value1 = context.valueOf(640320);
+ * </pre>
  *
  * <p>The <code>BigFloat</code> instance holds a reference to the <code>Context</code>. This context is then passed from calculation to calculation.</p>
  * <pre>
-BigFloat value2 = context.valueOf(640320).pow(3).divide(24);
-BigFloat value3 = BigFloat.sin(value2);
-</pre>
+ * BigFloat value2 = context.valueOf(640320).pow(3).divide(24);
+ * BigFloat value3 = BigFloat.sin(value2);
+ * </pre>
  *
  * <p>The <code>BigFloat</code> result can be converted to other numerical types:</p>
  * <pre>
-BigDecimal bigDecimalValue = value3.toBigDecimal();
-double doubleValue = value3.toDouble();
-long longValue = value3.toLong();
-int intValue = value3.toInt();
-</pre>
+ * BigDecimal bigDecimalValue = value3.toBigDecimal();
+ * double doubleValue = value3.toDouble();
+ * long longValue = value3.toLong();
+ * int intValue = value3.toInt();
+ * </pre>
  */
 public class BigFloat implements Comparable<BigFloat> {
-	public static final BigFloat ZERO = new BigFloat(BigDecimal.valueOf(0),new Context(MathContext.DECIMAL64));
+	public static final BigFloat ZERO = new BigFloat(BigDecimal.valueOf(0), new Context(MathContext.DECIMAL64));
 	public static final BigFloat NAN;
 	public static final BigFloat POSITIVE_INFINITY;
 	public static final BigFloat NEGATIVE_INFINITY;
 
-	/**
-	 * Manages the {@link MathContext} and provides factory methods for {@link BigFloat} values.
-	 */
-	public static class Context {
-		private final MathContext mathContext;
-
-		private Context(MathContext mathContext) {
-			this.mathContext = mathContext;
-		}
-
-		/**
-		 * Returns the {@link MathContext} of this context.
-		 *
-		 * @return the {@link MathContext}
-		 */
-		public MathContext getMathContext() {
-			return mathContext;
-		}
-
-		/**
-		 * Returns the precision of this context.
-		 *
-		 * This is equivalent to calling <code>getMathContext().getPrecision()</code>.
-		 *
-		 * @return the precision
-		 */
-		public int getPrecision() {
-			return mathContext.getPrecision();
-		}
-
-		/**
-		 * Returns the {@link RoundingMode} of this context.
-		 *
-		 * This is equivalent to calling <code>getMathContext().getRoundingMode()</code>.
-		 *
-		 * @return the {@link RoundingMode}
-		 */
-		public RoundingMode getRoundingMode() {
-			return mathContext.getRoundingMode();
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source {@link BigFloat} value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(BigFloat value) {
-			return new BigFloat(value.value.round(mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source {@link BigDecimal} value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(BigDecimal value) {
-			return new BigFloat(value.round(mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source int value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(int value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source long value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(long value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source double value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(double value) {
-			if(value==Double.POSITIVE_INFINITY)
-				return POSITIVE_INFINITY;
-			else if(value==Double.NEGATIVE_INFINITY)
-				return NEGATIVE_INFINITY;
-			else if(Double.isNaN(value))
-				return NAN;
-			return new BigFloat(new BigDecimal(String.valueOf(value), mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source String value
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 * @throws NumberFormatException if the value is not a valid number.
-		 */
-		public BigFloat valueOf(String value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Returns the constant pi with this context.
-		 *
-		 * @return pi with this context (rounded to the precision of this context)
-		 * @see BigDecimalMath#pi(MathContext)
-		 */
-		public BigFloat pi() {
-			return valueOf(BigDecimalMath.pi(mathContext));
-		}
-
-		/**
-		 * Returns the constant e with this context.
-		 *
-		 * @return e with this context (rounded to the precision of this context)
-		 * @see BigDecimalMath#e(MathContext)
-		 */
-		public BigFloat e() {
-			return valueOf(BigDecimalMath.e(mathContext));
-		}
-
-		/**
-		 * Returns the factorial of n with this context.
-		 *
-		 * @param n the value to calculate
-		 * @return the factorial of n with this context (rounded to the precision of this context)
-		 * @see BigDecimalMath#factorial(int)
-		 */
-		public BigFloat factorial(int n) {
-			return valueOf(BigDecimalMath.factorial(n));
-		}
-
-		@Override
-		public int hashCode() {
-			return mathContext.hashCode();
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			Context other = (Context) obj;
-			return mathContext.equals(other.mathContext);
-		}
-
-		@Override
-		public String toString() {
-			return mathContext.toString();
-		}
+	static {
+		NAN = new SpecialBigFloat(TYPE.NAN);
+		NEGATIVE_INFINITY = new SpecialBigFloat(TYPE.NEGATIVE_INFINITY);
+		POSITIVE_INFINITY = new SpecialBigFloat(TYPE.POSITIVE_INFINITY);
 	}
 
 	private final BigDecimal value;
@@ -299,12 +143,433 @@ public class BigFloat implements Comparable<BigFloat> {
 	}
 
 	/**
+	 * Creates a {@link Context} with the specified precision and {@link RoundingMode#HALF_UP} rounding.
+	 *
+	 * @param precision the precision
+	 *
+	 * @return the {@link Context}
+	 */
+	public static Context context(int precision) {
+		return new Context(new MathContext(precision));
+	}
+
+	/**
+	 * Creates a {@link Context} with the specified {@link MathContext}.
+	 *
+	 * @param mathContext the {@link MathContext}
+	 *
+	 * @return the {@link Context}
+	 */
+	public static Context context(MathContext mathContext) {
+		return new Context(mathContext);
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>- this</code>.
+	 *
+	 * @param x the value to negate
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#negate(MathContext)
+	 */
+	public static BigFloat negate(BigFloat x) {
+		return x.context.valueOf(x.value.negate());
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>abs(this)</code> (absolute value).
+	 *
+	 * @param x the value to make absolute
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#abs(MathContext)
+	 */
+	public static BigFloat abs(BigFloat x) {
+		return x.context.valueOf(x.value.abs());
+	}
+
+	/**
+	 * Returns the the maximum of two {@link BigFloat} values.
+	 *
+	 * @param value1 the first {@link BigFloat} value to compare
+	 * @param value2 the second {@link BigFloat} value to compare
+	 *
+	 * @return the maximum {@link BigFloat} value
+	 */
+	public static BigFloat max(BigFloat value1, BigFloat value2) {
+		return value1.compareTo(value2) >= 0 ? value1 : value2;
+	}
+
+	/**
+	 * Returns the the maximum of n {@link BigFloat} values.
+	 *
+	 * @param value1 the first {@link BigFloat} value to compare
+	 * @param values the other {@link BigFloat}s value to compare
+	 *
+	 * @return the maximum {@link BigFloat} value
+	 */
+	public static BigFloat max(BigFloat value1, BigFloat... values) {
+		BigFloat result = value1;
+
+		for (BigFloat other : values) {
+			result = max(result, other);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns the the minimum of two {@link BigFloat} values.
+	 *
+	 * @param value1 the first {@link BigFloat} value to compare
+	 * @param value2 the second {@link BigFloat} value to compare
+	 *
+	 * @return the minimum {@link BigFloat} value
+	 */
+	public static BigFloat min(BigFloat value1, BigFloat value2) {
+		return value1.compareTo(value2) < 0 ? value1 : value2;
+	}
+
+	/**
+	 * Returns the the minimum of n {@link BigFloat} values.
+	 *
+	 * @param value1 the first {@link BigFloat} value to compare
+	 * @param values the other {@link BigFloat}s value to compare
+	 *
+	 * @return the minimum {@link BigFloat} value
+	 */
+	public static BigFloat min(BigFloat value1, BigFloat... values) {
+		BigFloat result = value1;
+
+		for (BigFloat other : values) {
+			result = min(result, other);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>log(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#log(BigDecimal, MathContext)
+	 */
+	public static BigFloat log(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.log(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>log2(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#log2(BigDecimal, MathContext)
+	 */
+	public static BigFloat log2(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.log2(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>log10(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#log10(BigDecimal, MathContext)
+	 */
+	public static BigFloat log10(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.log10(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>exp(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#exp(BigDecimal, MathContext)
+	 */
+	public static BigFloat exp(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.exp(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>sqrt(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#sqrt(BigDecimal, MathContext)
+	 */
+	public static BigFloat sqrt(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.sqrt(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>pow(x, y)</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the {@link BigFloat} value to take to the power
+	 * @param y the {@link BigFloat} value to serve as exponent
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public static BigFloat pow(BigFloat x, BigFloat y) {
+		Context c = max(x.context, y.context);
+		return c.valueOf(BigDecimalMath.pow(x.value, y.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>root(x, y)</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the {@link BigFloat} value to calculate the n'th root
+	 * @param y the {@link BigFloat} defining the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public static BigFloat root(BigFloat x, BigFloat y) {
+		Context c = max(x.context, y.context);
+		return c.valueOf(BigDecimalMath.root(x.value, y.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>sin(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#sin(BigDecimal, MathContext)
+	 */
+	public static BigFloat sin(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.sin(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>cos(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#cos(BigDecimal, MathContext)
+	 */
+	public static BigFloat cos(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.cos(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>tan(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#tan(BigDecimal, MathContext)
+	 */
+	public static BigFloat tan(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.tan(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>cot(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#cot(BigDecimal, MathContext)
+	 */
+	public static BigFloat cot(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.cot(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>asin(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#asin(BigDecimal, MathContext)
+	 */
+	public static BigFloat asin(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.asin(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>acos(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#acos(BigDecimal, MathContext)
+	 */
+	public static BigFloat acos(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.acos(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>atan(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#atan(BigDecimal, MathContext)
+	 */
+	public static BigFloat atan(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.atan(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>acot(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#acot(BigDecimal, MathContext)
+	 */
+	public static BigFloat acot(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.acot(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>sinh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#sinh(BigDecimal, MathContext)
+	 */
+	public static BigFloat sinh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.sinh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>cosh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#cosh(BigDecimal, MathContext)
+	 */
+	public static BigFloat cosh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.cosh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>tanh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#tanh(BigDecimal, MathContext)
+	 */
+	public static BigFloat tanh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.tanh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>coth(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#coth(BigDecimal, MathContext)
+	 */
+	public static BigFloat coth(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.coth(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>asinh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#asinh(BigDecimal, MathContext)
+	 */
+	public static BigFloat asinh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.asinh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>acosh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#acosh(BigDecimal, MathContext)
+	 */
+	public static BigFloat acosh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.acosh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>atanh(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#atanh(BigDecimal, MathContext)
+	 */
+	public static BigFloat atanh(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.atanh(x.value, x.context.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>acoth(x)</code>.
+	 *
+	 * @param x the value
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#acoth(BigDecimal, MathContext)
+	 */
+	public static BigFloat acoth(BigFloat x) {
+		return x.context.valueOf(BigDecimalMath.acoth(x.value, x.context.mathContext));
+	}
+
+	private static Context max(Context left, Context right) {
+		return left.mathContext.getPrecision() > right.mathContext.getPrecision() ? left : right;
+	}
+
+	/**
 	 * Returns the {@link BigFloat} that is <code>this + x</code>.
 	 *
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param x the value to add
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(BigFloat x) {
@@ -316,7 +581,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this + x</code>.
 	 *
 	 * @param x the value to add
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(BigDecimal x) {
@@ -327,7 +594,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this + x</code>.
 	 *
 	 * @param x the value to add
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(int x) {
@@ -338,7 +607,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this + x</code>.
 	 *
 	 * @param x the value to add
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(long x) {
@@ -349,7 +620,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this + x</code>.
 	 *
 	 * @param x the value to add
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#add(BigDecimal, MathContext)
 	 */
 	public BigFloat add(double x) {
@@ -362,7 +635,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param x the value to subtract
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(BigFloat x) {
@@ -374,7 +649,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this - x</code>.
 	 *
 	 * @param x the value to subtract
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(BigDecimal x) {
@@ -385,7 +662,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this - x</code>.
 	 *
 	 * @param x the value to subtract
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(int x) {
@@ -396,7 +675,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this - x</code>.
 	 *
 	 * @param x the value to subtract
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(long x) {
@@ -407,7 +688,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this - x</code>.
 	 *
 	 * @param x the value to subtract
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#subtract(BigDecimal, MathContext)
 	 */
 	public BigFloat subtract(double x) {
@@ -420,7 +703,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param x the value to multiply
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(BigFloat x) {
@@ -432,7 +717,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this * x</code>.
 	 *
 	 * @param x the value to multiply
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(BigDecimal x) {
@@ -443,7 +730,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this * x</code>.
 	 *
 	 * @param x the value to multiply
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(int x) {
@@ -454,7 +743,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this * x</code>.
 	 *
 	 * @param x the value to multiply
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(long x) {
@@ -465,7 +756,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this * x</code>.
 	 *
 	 * @param x the value to multiply
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#multiply(BigDecimal, MathContext)
 	 */
 	public BigFloat multiply(double x) {
@@ -478,12 +771,14 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#divide(BigDecimal, MathContext)
 	 */
 	public BigFloat divide(BigFloat x) {
-		if(x.isSpecial())
-			if(x.specialType() != TYPE.NAN)
+		if (x.isSpecial())
+			if (x.specialType() != TYPE.NAN)
 				return x;
 			else
 				SpecialBigFloat.throwNan();
@@ -495,7 +790,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this / x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#divide(BigDecimal, MathContext)
 	 */
 	public BigFloat divide(BigDecimal x) {
@@ -506,7 +803,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this / x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#divide(BigDecimal, MathContext)
 	 */
 	public BigFloat divide(int x) {
@@ -517,7 +816,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this / x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#divide(BigDecimal, MathContext)
 	 */
 	public BigFloat divide(long x) {
@@ -528,7 +829,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this / x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#divide(BigDecimal, MathContext)
 	 */
 	public BigFloat divide(double x) {
@@ -541,12 +844,14 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#remainder(BigDecimal, MathContext)
 	 */
 	public BigFloat remainder(BigFloat x) {
-		if(x.isSpecial())
-			if(x.specialType() != TYPE.NAN)
+		if (x.isSpecial())
+			if (x.specialType() != TYPE.NAN)
 				return x;
 			else
 				SpecialBigFloat.throwNan();
@@ -558,7 +863,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#remainder(BigDecimal, MathContext)
 	 */
 	public BigFloat remainder(BigDecimal x) {
@@ -569,7 +876,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#remainder(BigDecimal, MathContext)
 	 */
 	public BigFloat remainder(int x) {
@@ -580,7 +889,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#remainder(BigDecimal, MathContext)
 	 */
 	public BigFloat remainder(long x) {
@@ -591,7 +902,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
 	 *
 	 * @param x the value to divide with
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimal#remainder(BigDecimal, MathContext)
 	 */
 	public BigFloat remainder(double x) {
@@ -604,12 +917,14 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param y the value of the power
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat pow(BigFloat y) {
-		if(y.isSpecial())
-			if(y.specialType() != TYPE.NAN)
+		if (y.isSpecial())
+			if (y.specialType() != TYPE.NAN)
 				return y;
 			else
 				SpecialBigFloat.throwNan();
@@ -621,7 +936,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
 	 *
 	 * @param y the value of the power
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat pow(BigDecimal y) {
@@ -632,7 +949,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
 	 *
 	 * @param y the value of the power
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat pow(int y) {
@@ -643,7 +962,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
 	 *
 	 * @param y the value of the power
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat pow(long y) {
@@ -654,7 +975,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
 	 *
 	 * @param y the value of the power
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat pow(double y) {
@@ -667,12 +990,14 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
 	 *
 	 * @param y the value of the root
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat root(BigFloat y) {
-		if(y.isSpecial())
-			if(y.specialType() != TYPE.NAN)
+		if (y.isSpecial())
+			if (y.specialType() != TYPE.NAN)
 				return y;
 			else
 				SpecialBigFloat.throwNan();
@@ -684,7 +1009,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
 	 *
 	 * @param y the value of the root
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat root(BigDecimal y) {
@@ -695,7 +1022,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
 	 *
 	 * @param y the value of the root
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat root(int y) {
@@ -706,7 +1035,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
 	 *
 	 * @param y the value of the root
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat root(long y) {
@@ -717,7 +1048,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
 	 *
 	 * @param y the value of the root
+	 *
 	 * @return the resulting {@link BigFloat}
+	 *
 	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
 	 */
 	public BigFloat root(double y) {
@@ -743,11 +1076,11 @@ public class BigFloat implements Comparable<BigFloat> {
 		//return Objects.equals(value, other.value) && Objects.equals(context, other.context);
 	}
 
-    /**
-     * Returns the signum function of this {@link BigFloat}.
-     *
-     * @return -1, 0, or 1 as the value of this {@link BigDecimal} is negative, zero, or positive.
-     */
+	/**
+	 * Returns the signum function of this {@link BigFloat}.
+	 *
+	 * @return -1, 0, or 1 as the value of this {@link BigDecimal} is negative, zero, or positive.
+	 */
 	public int signum() {
 		return value.signum();
 	}
@@ -788,7 +1121,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> value is mathematically equal to the <code>other</code> value.
 	 *
 	 * @param other the other {@link BigFloat} to compare with
+	 *
 	 * @return <code>true</code> if both values are mathematically equal (equivalent to <code>this.compareTo(other) == 0</code>
+	 *
 	 * @see #compareTo(BigFloat)
 	 */
 	public boolean isEqual(BigFloat other) {
@@ -799,7 +1134,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> value is mathematically less than to the <code>other</code> value.
 	 *
 	 * @param other the other {@link BigFloat} to compare with
+	 *
 	 * @return <code>true</code> <code>this</code> value is mathematically less than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt; 0</code>
+	 *
 	 * @see #compareTo(BigFloat)
 	 */
 	public boolean isLessThan(BigFloat other) {
@@ -810,7 +1147,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> value is mathematically greater than to the <code>other</code> value.
 	 *
 	 * @param other the other {@link BigFloat} to compare with
+	 *
 	 * @return <code>true</code> <code>this</code> value is mathematically greater than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt; 0</code>
+	 *
 	 * @see #compareTo(BigFloat)
 	 */
 	public boolean isGreaterThan(BigFloat other) {
@@ -821,7 +1160,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> value is mathematically less than or equal to the <code>other</code> value.
 	 *
 	 * @param other the other {@link BigFloat} to compare with
+	 *
 	 * @return <code>true</code> <code>this</code> value is mathematically less than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt;= 0</code>
+	 *
 	 * @see #compareTo(BigFloat)
 	 * @see #isLessThan(BigFloat)
 	 * @see #isEqual(BigFloat)
@@ -834,7 +1175,9 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> value is mathematically greater than or equal to the <code>other</code> value.
 	 *
 	 * @param other the other {@link BigFloat} to compare with
+	 *
 	 * @return <code>true</code> <code>this</code> value is mathematically greater than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt;= 0</code>
+	 *
 	 * @see #compareTo(BigFloat)
 	 * @see #isGreaterThan(BigFloat)
 	 * @see #isEqual(BigFloat)
@@ -843,11 +1186,11 @@ public class BigFloat implements Comparable<BigFloat> {
 		return compareTo(other) >= 0;
 	}
 
-
 	/**
 	 * Returns whether <code>this</code> value can be represented as <code>int</code>.
 	 *
 	 * @return <code>true</code> if the value can be represented as <code>int</code> value
+	 *
 	 * @see BigDecimalMath#isIntValue(BigDecimal)
 	 */
 	public boolean isIntValue() {
@@ -858,6 +1201,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns whether <code>this</code> specified {@link BigDecimal} value can be represented as <code>double</code>.
 	 *
 	 * @return <code>true</code> if the value can be represented as <code>double</code> value
+	 *
 	 * @see BigDecimalMath#isDoubleValue(BigDecimal)
 	 */
 	public boolean isDoubleValue() {
@@ -870,6 +1214,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
 	 *
 	 * @return the mantissa
+	 *
 	 * @see #getExponent()
 	 * @see BigDecimalMath#mantissa(BigDecimal)
 	 */
@@ -883,6 +1228,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
 	 *
 	 * @return the exponent
+	 *
 	 * @see #getMantissa()
 	 * @see BigDecimalMath#exponent(BigDecimal)
 	 */
@@ -894,6 +1240,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the integral part of <code>this</code> value (left of the decimal point).
 	 *
 	 * @return the integral part
+	 *
 	 * @see #getFractionalPart()
 	 * @see BigDecimalMath#fractionalPart(BigDecimal)
 	 */
@@ -905,6 +1252,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns the fractional part of <code>this</code> value (right of the decimal point).
 	 *
 	 * @return the fractional part
+	 *
 	 * @see #getIntegralPart()
 	 * @see BigDecimalMath#fractionalPart(BigDecimal)
 	 */
@@ -934,6 +1282,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns <code>this</code> value as a <code>double</code> value.
 	 *
 	 * @return the <code>double</code> value
+	 *
 	 * @see BigDecimal#doubleValue()
 	 */
 	public double toDouble() {
@@ -944,6 +1293,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns <code>this</code> value as a <code>long</code> value.
 	 *
 	 * @return the <code>long</code> value
+	 *
 	 * @see BigDecimal#longValue()
 	 */
 	public long toLong() {
@@ -954,6 +1304,7 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * Returns <code>this</code> value as a <code>int</code> value.
 	 *
 	 * @return the <code>int</code> value
+	 *
 	 * @see BigDecimal#intValue()
 	 */
 	public int toInt() {
@@ -965,375 +1316,185 @@ public class BigFloat implements Comparable<BigFloat> {
 		return value.toString();
 	}
 
-	/**
-	 * Creates a {@link Context} with the specified precision and {@link RoundingMode#HALF_UP} rounding.
-	 *
-	 * @param precision the precision
-	 * @return the {@link Context}
-	 */
-	public static Context context(int precision) {
-		return new Context(new MathContext(precision));
-	}
-
-	/**
-	 * Creates a {@link Context} with the specified {@link MathContext}.
-	 *
-	 * @param mathContext the {@link MathContext}
-	 * @return the {@link Context}
-	 */
-	public static Context context(MathContext mathContext) {
-		return new Context(mathContext);
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>- this</code>.
-	 *
-	 * @param x the value to negate
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimal#negate(MathContext)
-	 */
-	public static BigFloat negate(BigFloat x) {
-		return x.context.valueOf(x.value.negate());
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>abs(this)</code> (absolute value).
-	 *
-	 * @param x the value to make absolute
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimal#abs(MathContext)
-	 */
-	public static BigFloat abs(BigFloat x) {
-		return x.context.valueOf(x.value.abs());
-	}
-
-	/**
-	 * Returns the the maximum of two {@link BigFloat} values.
-	 *
-	 * @param value1 the first {@link BigFloat} value to compare
-	 * @param value2 the second {@link BigFloat} value to compare
-	 * @return the maximum {@link BigFloat} value
-	 */
-	public static BigFloat max(BigFloat value1, BigFloat value2) {
-		return value1.compareTo(value2) >= 0 ? value1 : value2;
-	}
-
-	/**
-	 * Returns the the maximum of n {@link BigFloat} values.
-	 *
-	 * @param value1 the first {@link BigFloat} value to compare
-	 * @param values the other {@link BigFloat}s value to compare
-	 * @return the maximum {@link BigFloat} value
-	 */
-	public static BigFloat max(BigFloat value1, BigFloat... values) {
-		BigFloat result = value1;
-
-		for (BigFloat other : values) {
-			result = max(result, other);
-		}
-
-		return result;
-	}
-
-	/**
-	 * Returns the the minimum of two {@link BigFloat} values.
-	 *
-	 * @param value1 the first {@link BigFloat} value to compare
-	 * @param value2 the second {@link BigFloat} value to compare
-	 * @return the minimum {@link BigFloat} value
-	 */
-	public static BigFloat min(BigFloat value1, BigFloat value2) {
-		return value1.compareTo(value2) < 0 ? value1 : value2;
-	}
-
-	/**
-	 * Returns the the minimum of n {@link BigFloat} values.
-	 *
-	 * @param value1 the first {@link BigFloat} value to compare
-	 * @param values the other {@link BigFloat}s value to compare
-	 * @return the minimum {@link BigFloat} value
-	 */
-	public static BigFloat min(BigFloat value1, BigFloat... values) {
-		BigFloat result = value1;
-
-		for (BigFloat other : values) {
-			result = min(result, other);
-		}
-
-		return result;
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>log(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#log(BigDecimal, MathContext)
-	 */
-	public static BigFloat log(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.log(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>log2(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#log2(BigDecimal, MathContext)
-	 */
-	public static BigFloat log2(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.log2(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>log10(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#log10(BigDecimal, MathContext)
-	 */
-	public static BigFloat log10(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.log10(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>exp(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#exp(BigDecimal, MathContext)
-	 */
-	public static BigFloat exp(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.exp(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>sqrt(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#sqrt(BigDecimal, MathContext)
-	 */
-	public static BigFloat sqrt(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.sqrt(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>pow(x, y)</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the {@link BigFloat} value to take to the power
-	 * @param y the {@link BigFloat} value to serve as exponent
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public static BigFloat pow(BigFloat x, BigFloat y) {
-		Context c = max(x.context, y.context);
-		return c.valueOf(BigDecimalMath.pow(x.value, y.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>root(x, y)</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the {@link BigFloat} value to calculate the n'th root
-	 * @param y the {@link BigFloat} defining the root
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public static BigFloat root(BigFloat x, BigFloat y) {
-		Context c = max(x.context, y.context);
-		return c.valueOf(BigDecimalMath.root(x.value, y.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>sin(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#sin(BigDecimal, MathContext)
-	 */
-	public static BigFloat sin(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.sin(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>cos(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#cos(BigDecimal, MathContext)
-	 */
-	public static BigFloat cos(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.cos(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>tan(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#tan(BigDecimal, MathContext)
-	 */
-	public static BigFloat tan(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.tan(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>cot(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#cot(BigDecimal, MathContext)
-	 */
-	public static BigFloat cot(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.cot(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>asin(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#asin(BigDecimal, MathContext)
-	 */
-	public static BigFloat asin(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.asin(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>acos(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#acos(BigDecimal, MathContext)
-	 */
-	public static BigFloat acos(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.acos(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>atan(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#atan(BigDecimal, MathContext)
-	 */
-	public static BigFloat atan(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.atan(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>acot(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#acot(BigDecimal, MathContext)
-	 */
-	public static BigFloat acot(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.acot(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>sinh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#sinh(BigDecimal, MathContext)
-	 */
-	public static BigFloat sinh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.sinh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>cosh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#cosh(BigDecimal, MathContext)
-	 */
-	public static BigFloat cosh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.cosh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>tanh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#tanh(BigDecimal, MathContext)
-	 */
-	public static BigFloat tanh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.tanh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>coth(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#coth(BigDecimal, MathContext)
-	 */
-	public static BigFloat coth(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.coth(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>asinh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#asinh(BigDecimal, MathContext)
-	 */
-	public static BigFloat asinh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.asinh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>acosh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#acosh(BigDecimal, MathContext)
-	 */
-	public static BigFloat acosh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.acosh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>atanh(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#atanh(BigDecimal, MathContext)
-	 */
-	public static BigFloat atanh(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.atanh(x.value, x.context.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>acoth(x)</code>.
-	 *
-	 * @param x the value
-	 * @return the resulting {@link BigFloat}
-	 * @see BigDecimalMath#acoth(BigDecimal, MathContext)
-	 */
-	public static BigFloat acoth(BigFloat x) {
-		return x.context.valueOf(BigDecimalMath.acoth(x.value, x.context.mathContext));
-	}
-
-	private static Context max(Context left, Context right) {
-		return left.mathContext.getPrecision() > right.mathContext.getPrecision() ? left : right;
-	}
-
 	public boolean isSpecial() {
 		return false;
 	}
 
 	public TYPE specialType() {
 		return TYPE.UNKNOWN; //BigFloat is presentable value
+	}
+
+	/**
+	 * Manages the {@link MathContext} and provides factory methods for {@link BigFloat} values.
+	 */
+	public static class Context {
+		private final MathContext mathContext;
+
+		private Context(MathContext mathContext) {
+			this.mathContext = mathContext;
+		}
+
+		/**
+		 * Returns the {@link MathContext} of this context.
+		 *
+		 * @return the {@link MathContext}
+		 */
+		public MathContext getMathContext() {
+			return mathContext;
+		}
+
+		/**
+		 * Returns the precision of this context.
+		 * <p>
+		 * This is equivalent to calling <code>getMathContext().getPrecision()</code>.
+		 *
+		 * @return the precision
+		 */
+		public int getPrecision() {
+			return mathContext.getPrecision();
+		}
+
+		/**
+		 * Returns the {@link RoundingMode} of this context.
+		 * <p>
+		 * This is equivalent to calling <code>getMathContext().getRoundingMode()</code>.
+		 *
+		 * @return the {@link RoundingMode}
+		 */
+		public RoundingMode getRoundingMode() {
+			return mathContext.getRoundingMode();
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source {@link BigFloat} value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(BigFloat value) {
+			return new BigFloat(value.value.round(mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source {@link BigDecimal} value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(BigDecimal value) {
+			return new BigFloat(value.round(mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source int value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(int value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source long value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(long value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source double value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(double value) {
+			if (value == Double.POSITIVE_INFINITY)
+				return POSITIVE_INFINITY;
+			else if (value == Double.NEGATIVE_INFINITY)
+				return NEGATIVE_INFINITY;
+			else if (Double.isNaN(value))
+				return NAN;
+			return new BigFloat(new BigDecimal(String.valueOf(value), mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source String value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 *
+		 * @throws NumberFormatException if the value is not a valid number.
+		 */
+		public BigFloat valueOf(String value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Returns the constant pi with this context.
+		 *
+		 * @return pi with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#pi(MathContext)
+		 */
+		public BigFloat pi() {
+			return valueOf(BigDecimalMath.pi(mathContext));
+		}
+
+		/**
+		 * Returns the constant e with this context.
+		 *
+		 * @return e with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#e(MathContext)
+		 */
+		public BigFloat e() {
+			return valueOf(BigDecimalMath.e(mathContext));
+		}
+
+		/**
+		 * Returns the factorial of n with this context.
+		 *
+		 * @param n the value to calculate
+		 *
+		 * @return the factorial of n with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#factorial(int)
+		 */
+		public BigFloat factorial(int n) {
+			return valueOf(BigDecimalMath.factorial(n));
+		}
+
+		@Override
+		public int hashCode() {
+			return mathContext.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Context other = (Context) obj;
+			return mathContext.equals(other.mathContext);
+		}
+
+		@Override
+		public String toString() {
+			return mathContext.toString();
+		}
 	}
 
 	/**
@@ -1358,8 +1519,8 @@ public class BigFloat implements Comparable<BigFloat> {
 			this.type = type;
 		}
 
-		private static BigFloat valueOf(TYPE type){
-			switch (type){
+		private static BigFloat valueOf(TYPE type) {
+			switch (type) {
 				case POSITIVE_INFINITY:
 					return POSITIVE_INFINITY;
 				case NEGATIVE_INFINITY:
@@ -1371,19 +1532,24 @@ public class BigFloat implements Comparable<BigFloat> {
 			}
 		}
 
-		private static void checkUnsupported(BigFloat...bigFloats){
+		private static void checkUnsupported(BigFloat... bigFloats) {
 			for (BigFloat val : bigFloats)
-				if(val.isSpecial())
+				if (val.isSpecial())
 					throw new NumberFormatException(val.toString());
 		}
-		public static BigFloat ofDouble(double d){
-			if(Double.isNaN(d))
+
+		public static BigFloat ofDouble(double d) {
+			if (Double.isNaN(d))
 				return BigFloat.NAN;
-			else if(d==Double.POSITIVE_INFINITY)
+			else if (d == Double.POSITIVE_INFINITY)
 				return BigFloat.POSITIVE_INFINITY;
-			else if(d==Double.NEGATIVE_INFINITY)
+			else if (d == Double.NEGATIVE_INFINITY)
 				return BigFloat.NEGATIVE_INFINITY;
-			else return new BigFloat(BigDecimal.valueOf(d),new Context(MathContext.DECIMAL64));
+			else return new BigFloat(BigDecimal.valueOf(d), new Context(MathContext.DECIMAL64));
+		}
+
+		private static void throwNan() {
+			throw new NumberFormatException("Not A Number");
 		}
 
 		private void checkNAN() {
@@ -1393,10 +1559,6 @@ public class BigFloat implements Comparable<BigFloat> {
 
 		private void unsupported() {
 			throw new NumberFormatException(this.toString());
-		}
-
-		private static void throwNan(){
-			throw new NumberFormatException("Not A Number");
 		}
 
 		@Override
@@ -1663,7 +1825,7 @@ public class BigFloat implements Comparable<BigFloat> {
 		@Override
 		public int compareTo(BigFloat other) {
 			checkNAN();
-			return TYPE.compare(type,other.specialType());
+			return TYPE.compare(type, other.specialType());
 		}
 
 		@Override
@@ -1760,39 +1922,33 @@ public class BigFloat implements Comparable<BigFloat> {
 			 */
 			UNKNOWN;
 
-			public static int compare(TYPE a,TYPE b){
+			public static int compare(TYPE a, TYPE b) {
 				//NAN less than everything
-				if(a == NAN)
+				if (a == NAN)
 					return -1;
-				if(b == NAN)
+				if (b == NAN)
 					return 1;
-				if(a == POSITIVE_INFINITY)
-					if(b == POSITIVE_INFINITY)
+				if (a == POSITIVE_INFINITY)
+					if (b == POSITIVE_INFINITY)
 						return 0;
-					else if(b == NEGATIVE_INFINITY)
+					else if (b == NEGATIVE_INFINITY)
 						return 1;
-					else if(b==UNKNOWN)
+					else if (b == UNKNOWN)
 						return 1;
-				if(a == NEGATIVE_INFINITY)
-					if(b == NEGATIVE_INFINITY)
+				if (a == NEGATIVE_INFINITY)
+					if (b == NEGATIVE_INFINITY)
 						return 0;
-					else if(b == POSITIVE_INFINITY)
+					else if (b == POSITIVE_INFINITY)
 						return -1;
-					else if(b==UNKNOWN)
+					else if (b == UNKNOWN)
 						return -1;
-				if(a == UNKNOWN)
-					if(b == NEGATIVE_INFINITY)
+				if (a == UNKNOWN)
+					if (b == NEGATIVE_INFINITY)
 						return -1;
-					else if(b == POSITIVE_INFINITY)
+					else if (b == POSITIVE_INFINITY)
 						return 1;
 				return 0;
 			}
 		}
-	}
-
-	static {
-		NAN = new SpecialBigFloat(TYPE.NAN);
-		NEGATIVE_INFINITY = new SpecialBigFloat(TYPE.NEGATIVE_INFINITY);
-		POSITIVE_INFINITY = new SpecialBigFloat(TYPE.POSITIVE_INFINITY);
 	}
 }

--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigFloat.java
@@ -1,5 +1,6 @@
 package ch.obermuhlner.math.big;
 
+import javax.naming.Context;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
@@ -122,16 +123,25 @@ import static ch.obermuhlner.math.big.BigFloat.SpecialBigFloat.TYPE;
  * int intValue = value3.toInt();
  * </pre>
  */
+@SuppressWarnings("WeakerAccess")
 public class BigFloat implements Comparable<BigFloat> {
+	//Cache small BigFloat value
+	public static final BigFloat NEGATIVE_ONE = new BigFloat(BigDecimal.valueOf(-1),
+			new Context(MathContext.DECIMAL64));
 	public static final BigFloat ZERO = new BigFloat(BigDecimal.valueOf(0), new Context(MathContext.DECIMAL64));
-	public static final BigFloat NAN;
+	public static final BigFloat ONE = new BigFloat(BigDecimal.valueOf(1), new Context(MathContext.DECIMAL64));
+
+	public static final BigFloat NaN;
 	public static final BigFloat POSITIVE_INFINITY;
 	public static final BigFloat NEGATIVE_INFINITY;
 
 	static {
-		NAN = new SpecialBigFloat(TYPE.NAN);
-		NEGATIVE_INFINITY = new SpecialBigFloat(TYPE.NEGATIVE_INFINITY);
-		POSITIVE_INFINITY = new SpecialBigFloat(TYPE.POSITIVE_INFINITY);
+		synchronized (SpecialBigFloat.class) {
+			NaN = SpecialBigFloat.NaN;
+			NEGATIVE_INFINITY = SpecialBigFloat.NEGATIVE_INFINITY;
+			//noinspection StaticInitializerReferencesSubClass
+			POSITIVE_INFINITY = SpecialBigFloat.POSITIVE_INFINITY;
+		}
 	}
 
 	private final BigDecimal value;
@@ -165,6 +175,1412 @@ public class BigFloat implements Comparable<BigFloat> {
 	}
 
 	/**
+	 * Returns the {@link BigFloat} that is <code>this + x</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the value to add
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#add(BigDecimal, MathContext)
+	 */
+	public BigFloat add(BigFloat x) {
+		Context c = max(context, x.context);
+		return c.valueOf(value.add(x.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this + x</code>.
+	 *
+	 * @param x the value to add
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#add(BigDecimal, MathContext)
+	 */
+	public BigFloat add(BigDecimal x) {
+		return add(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this + x</code>.
+	 *
+	 * @param x the value to add
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#add(BigDecimal, MathContext)
+	 */
+	public BigFloat add(int x) {
+		return add(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this + x</code>.
+	 *
+	 * @param x the value to add
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#add(BigDecimal, MathContext)
+	 */
+	public BigFloat add(long x) {
+		return add(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this + x</code>.
+	 *
+	 * @param x the value to add
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#add(BigDecimal, MathContext)
+	 */
+	public BigFloat add(double x) {
+		return add(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this - x</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the value to subtract
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#subtract(BigDecimal, MathContext)
+	 */
+	public BigFloat subtract(BigFloat x) {
+		Context c = max(context, x.context);
+		return c.valueOf(value.subtract(x.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this - x</code>.
+	 *
+	 * @param x the value to subtract
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#subtract(BigDecimal, MathContext)
+	 */
+	public BigFloat subtract(BigDecimal x) {
+		return subtract(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this - x</code>.
+	 *
+	 * @param x the value to subtract
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#subtract(BigDecimal, MathContext)
+	 */
+	public BigFloat subtract(int x) {
+		return subtract(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this - x</code>.
+	 *
+	 * @param x the value to subtract
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#subtract(BigDecimal, MathContext)
+	 */
+	public BigFloat subtract(long x) {
+		return subtract(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this - x</code>.
+	 *
+	 * @param x the value to subtract
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#subtract(BigDecimal, MathContext)
+	 */
+	public BigFloat subtract(double x) {
+		return subtract(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this * x</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the value to multiply
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#multiply(BigDecimal, MathContext)
+	 */
+	public BigFloat multiply(BigFloat x) {
+		Context c = max(context, x.context);
+		return c.valueOf(value.multiply(x.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this * x</code>.
+	 *
+	 * @param x the value to multiply
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#multiply(BigDecimal, MathContext)
+	 */
+	public BigFloat multiply(BigDecimal x) {
+		return multiply(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this * x</code>.
+	 *
+	 * @param x the value to multiply
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#multiply(BigDecimal, MathContext)
+	 */
+	public BigFloat multiply(int x) {
+		return multiply(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this * x</code>.
+	 *
+	 * @param x the value to multiply
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#multiply(BigDecimal, MathContext)
+	 */
+	public BigFloat multiply(long x) {
+		return multiply(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this * x</code>.
+	 *
+	 * @param x the value to multiply
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#multiply(BigDecimal, MathContext)
+	 */
+	public BigFloat multiply(double x) {
+		return multiply(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this / x</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context},
+	 * the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#divide(BigDecimal, MathContext)
+	 */
+	public BigFloat divide(BigFloat x) {
+		if (x.isSpecial())
+			if (x.specialType() != TYPE.NaN)
+				return x;
+			else
+				SpecialBigFloat.throwNan();
+		if (this.isZero() || x.isZero())
+			if (this.isZero() && x.isZero())
+				return NaN;
+			else {
+				if ((this.isZero() && x.equals(ONE)) || (x.isZero() && this.equals(ONE)))
+					return POSITIVE_INFINITY;
+				else if ((this.isZero() && x.equals(NEGATIVE_ONE)) || (x.isZero() && this.equals(NEGATIVE_ONE)))
+					return NEGATIVE_INFINITY;
+			}
+		Context c = max(context, x.context);
+		return c.valueOf(value.divide(x.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this / x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#divide(BigDecimal, MathContext)
+	 */
+	public BigFloat divide(BigDecimal x) {
+		return divide(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this / x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#divide(BigDecimal, MathContext)
+	 */
+	public BigFloat divide(int x) {
+		return divide(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this / x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#divide(BigDecimal, MathContext)
+	 */
+	public BigFloat divide(long x) {
+		return divide(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this / x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#divide(BigDecimal, MathContext)
+	 */
+	public BigFloat divide(double x) {
+		return divide(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#remainder(BigDecimal, MathContext)
+	 */
+	public BigFloat remainder(BigFloat x) {
+		if (x.isSpecial())
+			if (!x.isNaN())
+				return x;
+			else
+				SpecialBigFloat.throwNan();
+		Context c = max(context, x.context);
+		return c.valueOf(value.remainder(x.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#remainder(BigDecimal, MathContext)
+	 */
+	public BigFloat remainder(BigDecimal x) {
+		return remainder(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#remainder(BigDecimal, MathContext)
+	 */
+	public BigFloat remainder(int x) {
+		return remainder(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#remainder(BigDecimal, MathContext)
+	 */
+	public BigFloat remainder(long x) {
+		return remainder(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
+	 *
+	 * @param x the value to divide with
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimal#remainder(BigDecimal, MathContext)
+	 */
+	public BigFloat remainder(double x) {
+		return remainder(context.valueOf(x));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param y the value of the power
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat pow(BigFloat y) {
+		if (y.isSpecial())
+			if (!y.isNaN())
+				return y;
+			else
+				SpecialBigFloat.throwNan();
+		Context c = max(context, y.context);
+		return c.valueOf(BigDecimalMath.pow(this.value, y.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
+	 *
+	 * @param y the value of the power
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat pow(BigDecimal y) {
+		return pow(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
+	 *
+	 * @param y the value of the power
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat pow(int y) {
+		return pow(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
+	 *
+	 * @param y the value of the power
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat pow(long y) {
+		return pow(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
+	 *
+	 * @param y the value of the power
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat pow(double y) {
+		return pow(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
+	 *
+	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
+	 *
+	 * @param y the value of the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat root(BigFloat y) {
+		if (y.isSpecial())
+			if (y.specialType() != TYPE.NaN)
+				return y;
+			else
+				SpecialBigFloat.throwNan();
+		Context c = max(context, y.context);
+		return c.valueOf(BigDecimalMath.root(this.value, y.value, c.mathContext));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
+	 *
+	 * @param y the value of the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat root(BigDecimal y) {
+		return root(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
+	 *
+	 * @param y the value of the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat root(int y) {
+		return root(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
+	 *
+	 * @param y the value of the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat root(long y) {
+		return root(context.valueOf(y));
+	}
+
+	/**
+	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
+	 *
+	 * @param y the value of the root
+	 *
+	 * @return the resulting {@link BigFloat}
+	 *
+	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
+	 */
+	public BigFloat root(double y) {
+		return root(context.valueOf(y));
+	}
+
+	@Override
+	public int hashCode() {
+		return value.stripTrailingZeros().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		BigFloat other = (BigFloat) obj;
+
+		return value.compareTo(other.value) == 0;
+		//return Objects.equals(value, other.value) && Objects.equals(context, other.context);
+	}
+
+	/**
+	 * Returns the signum function of this {@link BigFloat}.
+	 *
+	 * @return -1, 0, or 1 as the value of this {@link BigDecimal} is negative, zero, or positive.
+	 */
+	public int signum() {
+		return value.signum();
+	}
+
+	/**
+	 * Returns whether this {@link BigFloat} is negative.
+	 *
+	 * @return <code>true</code> if negative, <code>false</code> if 0 or positive
+	 */
+	public boolean isNegative() {
+		return value.signum() < 0;
+	}
+
+	/**
+	 * Returns whether this {@link BigFloat} is 0.
+	 *
+	 * @return <code>true</code> if 0, <code>false</code> if negative or positive
+	 */
+	public boolean isZero() {
+		return value.signum() == 0;
+	}
+
+	/**
+	 * Returns whether this {@link BigFloat} is positive.
+	 *
+	 * @return <code>true</code> if positive, <code>false</code> if 0 or negative
+	 */
+	public boolean isPositive() {
+		return value.signum() > 0;
+	}
+
+	@Override
+	public int compareTo(BigFloat other) {
+		return value.compareTo(other.value);
+	}
+
+	/**
+	 * Returns whether <code>this</code> value is mathematically equal to the <code>other</code> value.
+	 *
+	 * @param other the other {@link BigFloat} to compare with
+	 *
+	 * @return <code>true</code> if both values are mathematically equal (equivalent to <code>this.compareTo(other) == 0</code>
+	 *
+	 * @see #compareTo(BigFloat)
+	 */
+	public boolean isEqual(BigFloat other) {
+		return compareTo(other) == 0;
+	}
+
+	/**
+	 * Returns whether <code>this</code> value is mathematically less than to the <code>other</code> value.
+	 *
+	 * @param other the other {@link BigFloat} to compare with
+	 *
+	 * @return <code>true</code> <code>this</code> value is mathematically less than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt; 0</code>
+	 *
+	 * @see #compareTo(BigFloat)
+	 */
+	public boolean isLessThan(BigFloat other) {
+		return compareTo(other) < 0;
+	}
+
+	/**
+	 * Returns whether <code>this</code> value is mathematically greater than to the <code>other</code> value.
+	 *
+	 * @param other the other {@link BigFloat} to compare with
+	 *
+	 * @return <code>true</code> <code>this</code> value is mathematically greater than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt; 0</code>
+	 *
+	 * @see #compareTo(BigFloat)
+	 */
+	public boolean isGreaterThan(BigFloat other) {
+		return compareTo(other) > 0;
+	}
+
+	/**
+	 * Returns whether <code>this</code> value is mathematically less than or equal to the <code>other</code> value.
+	 *
+	 * @param other the other {@link BigFloat} to compare with
+	 *
+	 * @return <code>true</code> <code>this</code> value is mathematically less than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt;= 0</code>
+	 *
+	 * @see #compareTo(BigFloat)
+	 * @see #isLessThan(BigFloat)
+	 * @see #isEqual(BigFloat)
+	 */
+	public boolean isLessThanOrEqual(BigFloat other) {
+		return compareTo(other) <= 0;
+	}
+
+	/**
+	 * Returns whether <code>this</code> value is mathematically greater than or equal to the <code>other</code> value.
+	 *
+	 * @param other the other {@link BigFloat} to compare with
+	 *
+	 * @return <code>true</code> <code>this</code> value is mathematically greater than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt;= 0</code>
+	 *
+	 * @see #compareTo(BigFloat)
+	 * @see #isGreaterThan(BigFloat)
+	 * @see #isEqual(BigFloat)
+	 */
+	public boolean isGreaterThanOrEqual(BigFloat other) {
+		return compareTo(other) >= 0;
+	}
+
+	/**
+	 * Returns whether <code>this</code> value can be represented as <code>int</code>.
+	 *
+	 * @return <code>true</code> if the value can be represented as <code>int</code> value
+	 *
+	 * @see BigDecimalMath#isIntValue(BigDecimal)
+	 */
+	public boolean isIntValue() {
+		return BigDecimalMath.isIntValue(value);
+	}
+
+	/**
+	 * Returns whether <code>this</code> specified {@link BigDecimal} value can be represented as <code>double</code>.
+	 *
+	 * @return <code>true</code> if the value can be represented as <code>double</code> value
+	 *
+	 * @see BigDecimalMath#isDoubleValue(BigDecimal)
+	 */
+	public boolean isDoubleValue() {
+		return BigDecimalMath.isDoubleValue(value);
+	}
+
+	/**
+	 * Returns the mantissa of <code>this</code> value written as <em>mantissa * 10<sup>exponent</sup></em>.
+	 *
+	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
+	 *
+	 * @return the mantissa
+	 *
+	 * @see #getExponent()
+	 * @see BigDecimalMath#mantissa(BigDecimal)
+	 */
+	public BigFloat getMantissa() {
+		return context.valueOf(BigDecimalMath.mantissa(value));
+	}
+
+	/**
+	 * Returns the exponent of <code>this</code> value written as <em>mantissa * 10<sup>exponent</sup></em>.
+	 *
+	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
+	 *
+	 * @return the exponent
+	 *
+	 * @see #getMantissa()
+	 * @see BigDecimalMath#exponent(BigDecimal)
+	 */
+	public BigFloat getExponent() {
+		return context.valueOf(BigDecimalMath.exponent(value));
+	}
+
+	/**
+	 * Returns the integral part of <code>this</code> value (left of the decimal point).
+	 *
+	 * @return the integral part
+	 *
+	 * @see #getFractionalPart()
+	 * @see BigDecimalMath#fractionalPart(BigDecimal)
+	 */
+	public BigFloat getIntegralPart() {
+		return context.valueOf(BigDecimalMath.integralPart(value));
+	}
+
+	/**
+	 * Returns the fractional part of <code>this</code> value (right of the decimal point).
+	 *
+	 * @return the fractional part
+	 *
+	 * @see #getIntegralPart()
+	 * @see BigDecimalMath#fractionalPart(BigDecimal)
+	 */
+	public BigFloat getFractionalPart() {
+		return context.valueOf(BigDecimalMath.fractionalPart(value));
+	}
+
+	/**
+	 * Returns the {@link Context} of <code>this</code> value.
+	 *
+	 * @return the {@link Context}
+	 */
+	public Context getContext() {
+		return context;
+	}
+
+	/**
+	 * Returns <code>this</code> value as a {@link BigDecimal} value.
+	 *
+	 * @return the {@link BigDecimal} value
+	 */
+	public BigDecimal toBigDecimal() {
+		return value;
+	}
+
+	/**
+	 * Returns <code>this</code> value as a <code>double</code> value.
+	 *
+	 * @return the <code>double</code> value
+	 *
+	 * @see BigDecimal#doubleValue()
+	 */
+	public double toDouble() {
+		return value.doubleValue();
+	}
+
+	/**
+	 * Returns <code>this</code> value as a <code>long</code> value.
+	 *
+	 * @return the <code>long</code> value
+	 *
+	 * @see BigDecimal#longValue()
+	 */
+	public long toLong() {
+		return value.longValue();
+	}
+
+	/**
+	 * Returns <code>this</code> value as a <code>int</code> value.
+	 *
+	 * @return the <code>int</code> value
+	 *
+	 * @see BigDecimal#intValue()
+	 */
+	public int toInt() {
+		return value.intValue();
+	}
+
+	@Override
+	public String toString() {
+		return value.toString();
+	}
+
+	public boolean isSpecial() {
+		return false;
+	}
+
+	public TYPE specialType() {
+		return TYPE.NORMAL; //BigFloat is presentable value
+	}
+
+	public boolean isNaN() {
+		return specialType() == TYPE.NaN;
+	}
+
+	public boolean isINFINITY() {
+		return specialType() == TYPE.POSITIVE_INFINITY || specialType() == TYPE.NEGATIVE_INFINITY;
+	}
+
+	/**
+	 * this class handle unrepresentable value in floating-point arithmetic
+	 *
+	 * @author Wireless4024
+	 */
+	@SuppressWarnings("WeakerAccess")
+	public static final class SpecialBigFloat extends BigFloat {
+		public static final BigFloat NaN = new SpecialBigFloat(TYPE.NaN);
+		public static final BigFloat POSITIVE_INFINITY = new SpecialBigFloat(TYPE.POSITIVE_INFINITY);
+		public static final BigFloat NEGATIVE_INFINITY = new SpecialBigFloat(TYPE.NEGATIVE_INFINITY);
+
+		private final TYPE type;
+
+		private SpecialBigFloat(TYPE type) {
+			//we don't need it because
+			//all method has been override
+			super(null, null);
+			this.type = type;
+		}
+
+		private static BigFloat valueOf(TYPE type) {
+			switch (type) {
+				case POSITIVE_INFINITY:
+					return POSITIVE_INFINITY;
+				case NEGATIVE_INFINITY:
+					return NEGATIVE_INFINITY;
+				case NaN:
+					return NaN;
+				default:
+					return ZERO;
+			}
+		}
+
+		private static void checkUnsupported(BigFloat... bigFloats) {
+			for (BigFloat val : bigFloats)
+				if (val.isSpecial())
+					throw new NumberFormatException(val.toString());
+		}
+
+		public static BigFloat ofDouble(double d) {
+			if (Double.isNaN(d))
+				return BigFloat.NaN;
+			else if (d == Double.POSITIVE_INFINITY)
+				return BigFloat.POSITIVE_INFINITY;
+			else if (d == Double.NEGATIVE_INFINITY)
+				return BigFloat.NEGATIVE_INFINITY;
+			else return new BigFloat(BigDecimal.valueOf(d), new Context(MathContext.DECIMAL64));
+		}
+
+		private static void throwNan() {
+			throw new NumberFormatException("Not a Number");
+		}
+
+		private void checkNaN() {
+			if (type == TYPE.NaN)
+				throw new NumberFormatException("Not a Number");
+		}
+
+		private void unsupported() {
+			throw new NumberFormatException(this.toString());
+		}
+
+		@Override
+		public boolean isSpecial() {
+			return true;
+		}
+
+		@Override
+		public TYPE specialType() {
+			return type;
+		}
+
+		@Override
+		public BigFloat add(BigFloat x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat add(BigDecimal x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat add(int x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat add(long x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat add(double x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat subtract(BigFloat x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat subtract(BigDecimal x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat subtract(int x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat subtract(long x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat subtract(double x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat multiply(BigFloat x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat multiply(BigDecimal x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat multiply(int x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat multiply(long x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat multiply(double x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat divide(BigFloat x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat divide(BigDecimal x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat divide(int x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat divide(long x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat divide(double x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat remainder(BigFloat x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat remainder(BigDecimal x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat remainder(int x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat remainder(long x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat remainder(double x) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat pow(BigFloat y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat pow(BigDecimal y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat pow(int y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat pow(long y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat pow(double y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat root(BigFloat y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat root(BigDecimal y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat root(int y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat root(long y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat root(double y) {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(toDouble());
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj instanceof BigFloat)
+				return ((BigFloat) obj).isSpecial() && ((BigFloat) obj).specialType() == this.type;
+			return false;
+		}
+
+		@Override
+		public int signum() {
+			switch (type) {
+				case POSITIVE_INFINITY:
+					return 1;
+				case NEGATIVE_INFINITY:
+					return -1;
+				default:
+					return 0;
+			}
+		}
+
+		@Override
+		public boolean isNegative() {
+			return signum() == -1;
+		}
+
+		@Override
+		public boolean isZero() {
+			return false;//nan or infinity is not a zero
+		}
+
+		@Override
+		public boolean isPositive() {
+			return signum() == 1;
+		}
+
+		@Override
+		public int compareTo(BigFloat other) {
+			checkNaN();
+			return TYPE.compare(type, other.specialType());
+		}
+
+		@Override
+		public boolean isIntValue() {
+			return false;//nope
+		}
+
+		@Override
+		public boolean isDoubleValue() {
+			return false;//nope
+		}
+
+		@Override
+		public BigFloat getMantissa() {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat getExponent() {
+			checkNaN();
+			return this;
+		}
+
+		@Override
+		public BigFloat getIntegralPart() {
+			unsupported();
+			return null;
+		}
+
+		@Override
+		public BigFloat getFractionalPart() {
+			unsupported();
+			return null;
+		}
+
+		@Override
+		public Context getContext() {
+			checkNaN();
+			unsupported();
+			return null;
+		}
+
+		@Override
+		public BigDecimal toBigDecimal() {
+			unsupported();
+			return null;//nope
+		}
+
+		@Override
+		public double toDouble() {
+			switch (type) {
+				case POSITIVE_INFINITY:
+					return Double.POSITIVE_INFINITY;
+				case NEGATIVE_INFINITY:
+					return Double.NEGATIVE_INFINITY;
+				case NaN:
+					return Double.NaN;
+				default:
+					return 0;
+			}
+		}
+
+		@Override
+		public long toLong() {
+			checkNaN();
+			return (long) toDouble();
+		}
+
+		@Override
+		public int toInt() {
+			checkNaN();
+			return (int) toDouble();
+		}
+
+		@Override
+		public String toString() {
+			switch (type) {
+				case NaN:
+					return "NaN";
+				case NEGATIVE_INFINITY:
+					return "-INF";
+				case POSITIVE_INFINITY:
+					return "+INF";
+				default:
+					return "NORMAL";
+			}
+		}
+
+		public static enum TYPE {
+			NaN,
+			POSITIVE_INFINITY,
+			NEGATIVE_INFINITY,
+			NORMAL;
+
+			public static int compare(TYPE a, TYPE b) {
+				//NaN less than everything
+				if (a == NaN)
+					return -1;
+				if (b == NaN)
+					return 1;
+				if (a == POSITIVE_INFINITY)
+					if (b == POSITIVE_INFINITY)
+						return 0;
+					else if (b == NEGATIVE_INFINITY)
+						return 1;
+					else if (b == NORMAL)
+						return 1;
+				if (a == NEGATIVE_INFINITY)
+					if (b == NEGATIVE_INFINITY)
+						return 0;
+					else if (b == POSITIVE_INFINITY)
+						return -1;
+					else if (b == NORMAL)
+						return -1;
+				if (a == NORMAL)
+					if (b == NEGATIVE_INFINITY)
+						return -1;
+					else if (b == POSITIVE_INFINITY)
+						return 1;
+				return 1;
+			}
+		}
+	}
+
+	/**
+	 * Manages the {@link MathContext} and provides factory methods for {@link BigFloat} values.
+	 */
+	public static class Context {
+		private final MathContext mathContext;
+
+		private Context(MathContext mathContext) {
+			this.mathContext = mathContext;
+		}
+
+		/**
+		 * Returns the {@link MathContext} of this context.
+		 *
+		 * @return the {@link MathContext}
+		 */
+		public MathContext getMathContext() {
+			return mathContext;
+		}
+
+		/**
+		 * Returns the precision of this context.
+		 * <p>
+		 * This is equivalent to calling <code>getMathContext().getPrecision()</code>.
+		 *
+		 * @return the precision
+		 */
+		public int getPrecision() {
+			return mathContext.getPrecision();
+		}
+
+		/**
+		 * Returns the {@link RoundingMode} of this context.
+		 * <p>
+		 * This is equivalent to calling <code>getMathContext().getRoundingMode()</code>.
+		 *
+		 * @return the {@link RoundingMode}
+		 */
+		public RoundingMode getRoundingMode() {
+			return mathContext.getRoundingMode();
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source {@link BigFloat} value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(BigFloat value) {
+			return new BigFloat(value.value.round(mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source {@link BigDecimal} value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(BigDecimal value) {
+			return new BigFloat(value.round(mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source int value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(int value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source long value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(long value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source double value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 */
+		public BigFloat valueOf(double value) {
+			if (value == Double.POSITIVE_INFINITY)
+				return POSITIVE_INFINITY;
+			else if (value == Double.NEGATIVE_INFINITY)
+				return NEGATIVE_INFINITY;
+			else if (Double.isNaN(value))
+				return NaN;
+			return new BigFloat(new BigDecimal(String.valueOf(value), mathContext), this);
+		}
+
+		/**
+		 * Creates a {@link BigFloat} value with this context.
+		 *
+		 * @param value the source String value
+		 *
+		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
+		 *
+		 * @throws NumberFormatException if the value is not a valid number.
+		 */
+		public BigFloat valueOf(String value) {
+			return new BigFloat(new BigDecimal(value, mathContext), this);
+		}
+
+		/**
+		 * Returns the constant pi with this context.
+		 *
+		 * @return pi with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#pi(MathContext)
+		 */
+		public BigFloat pi() {
+			return valueOf(BigDecimalMath.pi(mathContext));
+		}
+
+		/**
+		 * Returns the constant e with this context.
+		 *
+		 * @return e with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#e(MathContext)
+		 */
+		public BigFloat e() {
+			return valueOf(BigDecimalMath.e(mathContext));
+		}
+
+		/**
+		 * Returns the factorial of n with this context.
+		 *
+		 * @param n the value to calculate
+		 *
+		 * @return the factorial of n with this context (rounded to the precision of this context)
+		 *
+		 * @see BigDecimalMath#factorial(int)
+		 */
+		public BigFloat factorial(int n) {
+			return valueOf(BigDecimalMath.factorial(n));
+		}
+
+		@Override
+		public int hashCode() {
+			return mathContext.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Context other = (Context) obj;
+			return mathContext.equals(other.mathContext);
+		}
+
+		@Override
+		public String toString() {
+			return mathContext.toString();
+		}
+	}
+
+	/**
 	 * Returns the {@link BigFloat} that is <code>- this</code>.
 	 *
 	 * @param x the value to negate
@@ -174,6 +1590,14 @@ public class BigFloat implements Comparable<BigFloat> {
 	 * @see BigDecimal#negate(MathContext)
 	 */
 	public static BigFloat negate(BigFloat x) {
+		if (x.isSpecial())
+			if (x.specialType() != TYPE.NaN) {
+				if (x.specialType() == TYPE.POSITIVE_INFINITY)
+					return NEGATIVE_INFINITY;
+				else if (x.specialType() == TYPE.POSITIVE_INFINITY)
+					return NEGATIVE_INFINITY;
+			} else
+				SpecialBigFloat.throwNan();
 		return x.context.valueOf(x.value.negate());
 	}
 
@@ -559,1396 +1983,5 @@ public class BigFloat implements Comparable<BigFloat> {
 
 	private static Context max(Context left, Context right) {
 		return left.mathContext.getPrecision() > right.mathContext.getPrecision() ? left : right;
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this + x</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the value to add
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#add(BigDecimal, MathContext)
-	 */
-	public BigFloat add(BigFloat x) {
-		Context c = max(context, x.context);
-		return c.valueOf(value.add(x.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this + x</code>.
-	 *
-	 * @param x the value to add
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#add(BigDecimal, MathContext)
-	 */
-	public BigFloat add(BigDecimal x) {
-		return add(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this + x</code>.
-	 *
-	 * @param x the value to add
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#add(BigDecimal, MathContext)
-	 */
-	public BigFloat add(int x) {
-		return add(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this + x</code>.
-	 *
-	 * @param x the value to add
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#add(BigDecimal, MathContext)
-	 */
-	public BigFloat add(long x) {
-		return add(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this + x</code>.
-	 *
-	 * @param x the value to add
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#add(BigDecimal, MathContext)
-	 */
-	public BigFloat add(double x) {
-		return add(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this - x</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the value to subtract
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#subtract(BigDecimal, MathContext)
-	 */
-	public BigFloat subtract(BigFloat x) {
-		Context c = max(context, x.context);
-		return c.valueOf(value.subtract(x.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this - x</code>.
-	 *
-	 * @param x the value to subtract
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#subtract(BigDecimal, MathContext)
-	 */
-	public BigFloat subtract(BigDecimal x) {
-		return subtract(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this - x</code>.
-	 *
-	 * @param x the value to subtract
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#subtract(BigDecimal, MathContext)
-	 */
-	public BigFloat subtract(int x) {
-		return subtract(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this - x</code>.
-	 *
-	 * @param x the value to subtract
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#subtract(BigDecimal, MathContext)
-	 */
-	public BigFloat subtract(long x) {
-		return subtract(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this - x</code>.
-	 *
-	 * @param x the value to subtract
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#subtract(BigDecimal, MathContext)
-	 */
-	public BigFloat subtract(double x) {
-		return subtract(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this * x</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the value to multiply
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#multiply(BigDecimal, MathContext)
-	 */
-	public BigFloat multiply(BigFloat x) {
-		Context c = max(context, x.context);
-		return c.valueOf(value.multiply(x.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this * x</code>.
-	 *
-	 * @param x the value to multiply
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#multiply(BigDecimal, MathContext)
-	 */
-	public BigFloat multiply(BigDecimal x) {
-		return multiply(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this * x</code>.
-	 *
-	 * @param x the value to multiply
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#multiply(BigDecimal, MathContext)
-	 */
-	public BigFloat multiply(int x) {
-		return multiply(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this * x</code>.
-	 *
-	 * @param x the value to multiply
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#multiply(BigDecimal, MathContext)
-	 */
-	public BigFloat multiply(long x) {
-		return multiply(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this * x</code>.
-	 *
-	 * @param x the value to multiply
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#multiply(BigDecimal, MathContext)
-	 */
-	public BigFloat multiply(double x) {
-		return multiply(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this / x</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#divide(BigDecimal, MathContext)
-	 */
-	public BigFloat divide(BigFloat x) {
-		if (x.isSpecial())
-			if (x.specialType() != TYPE.NAN)
-				return x;
-			else
-				SpecialBigFloat.throwNan();
-		Context c = max(context, x.context);
-		return c.valueOf(value.divide(x.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this / x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#divide(BigDecimal, MathContext)
-	 */
-	public BigFloat divide(BigDecimal x) {
-		return divide(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this / x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#divide(BigDecimal, MathContext)
-	 */
-	public BigFloat divide(int x) {
-		return divide(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this / x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#divide(BigDecimal, MathContext)
-	 */
-	public BigFloat divide(long x) {
-		return divide(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this / x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#divide(BigDecimal, MathContext)
-	 */
-	public BigFloat divide(double x) {
-		return divide(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#remainder(BigDecimal, MathContext)
-	 */
-	public BigFloat remainder(BigFloat x) {
-		if (x.isSpecial())
-			if (x.specialType() != TYPE.NAN)
-				return x;
-			else
-				SpecialBigFloat.throwNan();
-		Context c = max(context, x.context);
-		return c.valueOf(value.remainder(x.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#remainder(BigDecimal, MathContext)
-	 */
-	public BigFloat remainder(BigDecimal x) {
-		return remainder(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#remainder(BigDecimal, MathContext)
-	 */
-	public BigFloat remainder(int x) {
-		return remainder(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#remainder(BigDecimal, MathContext)
-	 */
-	public BigFloat remainder(long x) {
-		return remainder(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the remainder when dividing <code>this</code> by <code>x</code>.
-	 *
-	 * @param x the value to divide with
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimal#remainder(BigDecimal, MathContext)
-	 */
-	public BigFloat remainder(double x) {
-		return remainder(context.valueOf(x));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param y the value of the power
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat pow(BigFloat y) {
-		if (y.isSpecial())
-			if (y.specialType() != TYPE.NAN)
-				return y;
-			else
-				SpecialBigFloat.throwNan();
-		Context c = max(context, y.context);
-		return c.valueOf(BigDecimalMath.pow(this.value, y.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
-	 *
-	 * @param y the value of the power
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat pow(BigDecimal y) {
-		return pow(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
-	 *
-	 * @param y the value of the power
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat pow(int y) {
-		return pow(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
-	 *
-	 * @param y the value of the power
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat pow(long y) {
-		return pow(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is <code>this</code> to the power of <code>y</code>.
-	 *
-	 * @param y the value of the power
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#pow(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat pow(double y) {
-		return pow(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
-	 *
-	 * <p>If the two values do not have the same {@link Context}, the result will contain the {@link Context} with the larger precision.</p>
-	 *
-	 * @param y the value of the root
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat root(BigFloat y) {
-		if (y.isSpecial())
-			if (y.specialType() != TYPE.NAN)
-				return y;
-			else
-				SpecialBigFloat.throwNan();
-		Context c = max(context, y.context);
-		return c.valueOf(BigDecimalMath.root(this.value, y.value, c.mathContext));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
-	 *
-	 * @param y the value of the root
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat root(BigDecimal y) {
-		return root(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
-	 *
-	 * @param y the value of the root
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat root(int y) {
-		return root(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
-	 *
-	 * @param y the value of the root
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat root(long y) {
-		return root(context.valueOf(y));
-	}
-
-	/**
-	 * Returns the {@link BigFloat} that is the <code>y</code>th root of <code>this</code>.
-	 *
-	 * @param y the value of the root
-	 *
-	 * @return the resulting {@link BigFloat}
-	 *
-	 * @see BigDecimalMath#root(BigDecimal, BigDecimal, MathContext)
-	 */
-	public BigFloat root(double y) {
-		return root(context.valueOf(y));
-	}
-
-	@Override
-	public int hashCode() {
-		return value.stripTrailingZeros().hashCode();
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		BigFloat other = (BigFloat) obj;
-
-		return value.compareTo(other.value) == 0;
-		//return Objects.equals(value, other.value) && Objects.equals(context, other.context);
-	}
-
-	/**
-	 * Returns the signum function of this {@link BigFloat}.
-	 *
-	 * @return -1, 0, or 1 as the value of this {@link BigDecimal} is negative, zero, or positive.
-	 */
-	public int signum() {
-		return value.signum();
-	}
-
-	/**
-	 * Returns whether this {@link BigFloat} is negative.
-	 *
-	 * @return <code>true</code> if negative, <code>false</code> if 0 or positive
-	 */
-	public boolean isNegative() {
-		return value.signum() < 0;
-	}
-
-	/**
-	 * Returns whether this {@link BigFloat} is 0.
-	 *
-	 * @return <code>true</code> if 0, <code>false</code> if negative or positive
-	 */
-	public boolean isZero() {
-		return value.signum() == 0;
-	}
-
-	/**
-	 * Returns whether this {@link BigFloat} is positive.
-	 *
-	 * @return <code>true</code> if positive, <code>false</code> if 0 or negative
-	 */
-	public boolean isPositive() {
-		return value.signum() > 0;
-	}
-
-	@Override
-	public int compareTo(BigFloat other) {
-		return value.compareTo(other.value);
-	}
-
-	/**
-	 * Returns whether <code>this</code> value is mathematically equal to the <code>other</code> value.
-	 *
-	 * @param other the other {@link BigFloat} to compare with
-	 *
-	 * @return <code>true</code> if both values are mathematically equal (equivalent to <code>this.compareTo(other) == 0</code>
-	 *
-	 * @see #compareTo(BigFloat)
-	 */
-	public boolean isEqual(BigFloat other) {
-		return compareTo(other) == 0;
-	}
-
-	/**
-	 * Returns whether <code>this</code> value is mathematically less than to the <code>other</code> value.
-	 *
-	 * @param other the other {@link BigFloat} to compare with
-	 *
-	 * @return <code>true</code> <code>this</code> value is mathematically less than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt; 0</code>
-	 *
-	 * @see #compareTo(BigFloat)
-	 */
-	public boolean isLessThan(BigFloat other) {
-		return compareTo(other) < 0;
-	}
-
-	/**
-	 * Returns whether <code>this</code> value is mathematically greater than to the <code>other</code> value.
-	 *
-	 * @param other the other {@link BigFloat} to compare with
-	 *
-	 * @return <code>true</code> <code>this</code> value is mathematically greater than to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt; 0</code>
-	 *
-	 * @see #compareTo(BigFloat)
-	 */
-	public boolean isGreaterThan(BigFloat other) {
-		return compareTo(other) > 0;
-	}
-
-	/**
-	 * Returns whether <code>this</code> value is mathematically less than or equal to the <code>other</code> value.
-	 *
-	 * @param other the other {@link BigFloat} to compare with
-	 *
-	 * @return <code>true</code> <code>this</code> value is mathematically less than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &lt;= 0</code>
-	 *
-	 * @see #compareTo(BigFloat)
-	 * @see #isLessThan(BigFloat)
-	 * @see #isEqual(BigFloat)
-	 */
-	public boolean isLessThanOrEqual(BigFloat other) {
-		return compareTo(other) <= 0;
-	}
-
-	/**
-	 * Returns whether <code>this</code> value is mathematically greater than or equal to the <code>other</code> value.
-	 *
-	 * @param other the other {@link BigFloat} to compare with
-	 *
-	 * @return <code>true</code> <code>this</code> value is mathematically greater than or equal to the <code>other</code> value (equivalent to <code>this.compareTo(other) &gt;= 0</code>
-	 *
-	 * @see #compareTo(BigFloat)
-	 * @see #isGreaterThan(BigFloat)
-	 * @see #isEqual(BigFloat)
-	 */
-	public boolean isGreaterThanOrEqual(BigFloat other) {
-		return compareTo(other) >= 0;
-	}
-
-	/**
-	 * Returns whether <code>this</code> value can be represented as <code>int</code>.
-	 *
-	 * @return <code>true</code> if the value can be represented as <code>int</code> value
-	 *
-	 * @see BigDecimalMath#isIntValue(BigDecimal)
-	 */
-	public boolean isIntValue() {
-		return BigDecimalMath.isIntValue(value);
-	}
-
-	/**
-	 * Returns whether <code>this</code> specified {@link BigDecimal} value can be represented as <code>double</code>.
-	 *
-	 * @return <code>true</code> if the value can be represented as <code>double</code> value
-	 *
-	 * @see BigDecimalMath#isDoubleValue(BigDecimal)
-	 */
-	public boolean isDoubleValue() {
-		return BigDecimalMath.isDoubleValue(value);
-	}
-
-	/**
-	 * Returns the mantissa of <code>this</code> value written as <em>mantissa * 10<sup>exponent</sup></em>.
-	 *
-	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
-	 *
-	 * @return the mantissa
-	 *
-	 * @see #getExponent()
-	 * @see BigDecimalMath#mantissa(BigDecimal)
-	 */
-	public BigFloat getMantissa() {
-		return context.valueOf(BigDecimalMath.mantissa(value));
-	}
-
-	/**
-	 * Returns the exponent of <code>this</code> value written as <em>mantissa * 10<sup>exponent</sup></em>.
-	 *
-	 * <p>The mantissa is defined as having exactly 1 digit before the decimal point.</p>
-	 *
-	 * @return the exponent
-	 *
-	 * @see #getMantissa()
-	 * @see BigDecimalMath#exponent(BigDecimal)
-	 */
-	public BigFloat getExponent() {
-		return context.valueOf(BigDecimalMath.exponent(value));
-	}
-
-	/**
-	 * Returns the integral part of <code>this</code> value (left of the decimal point).
-	 *
-	 * @return the integral part
-	 *
-	 * @see #getFractionalPart()
-	 * @see BigDecimalMath#fractionalPart(BigDecimal)
-	 */
-	public BigFloat getIntegralPart() {
-		return context.valueOf(BigDecimalMath.integralPart(value));
-	}
-
-	/**
-	 * Returns the fractional part of <code>this</code> value (right of the decimal point).
-	 *
-	 * @return the fractional part
-	 *
-	 * @see #getIntegralPart()
-	 * @see BigDecimalMath#fractionalPart(BigDecimal)
-	 */
-	public BigFloat getFractionalPart() {
-		return context.valueOf(BigDecimalMath.fractionalPart(value));
-	}
-
-	/**
-	 * Returns the {@link Context} of <code>this</code> value.
-	 *
-	 * @return the {@link Context}
-	 */
-	public Context getContext() {
-		return context;
-	}
-
-	/**
-	 * Returns <code>this</code> value as a {@link BigDecimal} value.
-	 *
-	 * @return the {@link BigDecimal} value
-	 */
-	public BigDecimal toBigDecimal() {
-		return value;
-	}
-
-	/**
-	 * Returns <code>this</code> value as a <code>double</code> value.
-	 *
-	 * @return the <code>double</code> value
-	 *
-	 * @see BigDecimal#doubleValue()
-	 */
-	public double toDouble() {
-		return value.doubleValue();
-	}
-
-	/**
-	 * Returns <code>this</code> value as a <code>long</code> value.
-	 *
-	 * @return the <code>long</code> value
-	 *
-	 * @see BigDecimal#longValue()
-	 */
-	public long toLong() {
-		return value.longValue();
-	}
-
-	/**
-	 * Returns <code>this</code> value as a <code>int</code> value.
-	 *
-	 * @return the <code>int</code> value
-	 *
-	 * @see BigDecimal#intValue()
-	 */
-	public int toInt() {
-		return value.intValue();
-	}
-
-	@Override
-	public String toString() {
-		return value.toString();
-	}
-
-	public boolean isSpecial() {
-		return false;
-	}
-
-	public TYPE specialType() {
-		return TYPE.UNKNOWN; //BigFloat is presentable value
-	}
-
-	/**
-	 * Manages the {@link MathContext} and provides factory methods for {@link BigFloat} values.
-	 */
-	public static class Context {
-		private final MathContext mathContext;
-
-		private Context(MathContext mathContext) {
-			this.mathContext = mathContext;
-		}
-
-		/**
-		 * Returns the {@link MathContext} of this context.
-		 *
-		 * @return the {@link MathContext}
-		 */
-		public MathContext getMathContext() {
-			return mathContext;
-		}
-
-		/**
-		 * Returns the precision of this context.
-		 * <p>
-		 * This is equivalent to calling <code>getMathContext().getPrecision()</code>.
-		 *
-		 * @return the precision
-		 */
-		public int getPrecision() {
-			return mathContext.getPrecision();
-		}
-
-		/**
-		 * Returns the {@link RoundingMode} of this context.
-		 * <p>
-		 * This is equivalent to calling <code>getMathContext().getRoundingMode()</code>.
-		 *
-		 * @return the {@link RoundingMode}
-		 */
-		public RoundingMode getRoundingMode() {
-			return mathContext.getRoundingMode();
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source {@link BigFloat} value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(BigFloat value) {
-			return new BigFloat(value.value.round(mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source {@link BigDecimal} value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(BigDecimal value) {
-			return new BigFloat(value.round(mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source int value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(int value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source long value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(long value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source double value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 */
-		public BigFloat valueOf(double value) {
-			if (value == Double.POSITIVE_INFINITY)
-				return POSITIVE_INFINITY;
-			else if (value == Double.NEGATIVE_INFINITY)
-				return NEGATIVE_INFINITY;
-			else if (Double.isNaN(value))
-				return NAN;
-			return new BigFloat(new BigDecimal(String.valueOf(value), mathContext), this);
-		}
-
-		/**
-		 * Creates a {@link BigFloat} value with this context.
-		 *
-		 * @param value the source String value
-		 *
-		 * @return the {@link BigFloat} value with this context (rounded to the precision of this context)
-		 *
-		 * @throws NumberFormatException if the value is not a valid number.
-		 */
-		public BigFloat valueOf(String value) {
-			return new BigFloat(new BigDecimal(value, mathContext), this);
-		}
-
-		/**
-		 * Returns the constant pi with this context.
-		 *
-		 * @return pi with this context (rounded to the precision of this context)
-		 *
-		 * @see BigDecimalMath#pi(MathContext)
-		 */
-		public BigFloat pi() {
-			return valueOf(BigDecimalMath.pi(mathContext));
-		}
-
-		/**
-		 * Returns the constant e with this context.
-		 *
-		 * @return e with this context (rounded to the precision of this context)
-		 *
-		 * @see BigDecimalMath#e(MathContext)
-		 */
-		public BigFloat e() {
-			return valueOf(BigDecimalMath.e(mathContext));
-		}
-
-		/**
-		 * Returns the factorial of n with this context.
-		 *
-		 * @param n the value to calculate
-		 *
-		 * @return the factorial of n with this context (rounded to the precision of this context)
-		 *
-		 * @see BigDecimalMath#factorial(int)
-		 */
-		public BigFloat factorial(int n) {
-			return valueOf(BigDecimalMath.factorial(n));
-		}
-
-		@Override
-		public int hashCode() {
-			return mathContext.hashCode();
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			Context other = (Context) obj;
-			return mathContext.equals(other.mathContext);
-		}
-
-		@Override
-		public String toString() {
-			return mathContext.toString();
-		}
-	}
-
-	/**
-	 * this class handle unrepresentable value in floating-point arithmetic
-	 *
-	 * @author Wireless4024
-	 */
-	@SuppressWarnings("WeakerAccess")
-	public static class SpecialBigFloat extends BigFloat {
-		public static final BigFloat UNKNOWN = ZERO;
-		public static final BigFloat NAN = new SpecialBigFloat(TYPE.NAN);
-		public static final BigFloat POSITIVE_INFINITY = new SpecialBigFloat(TYPE.POSITIVE_INFINITY);
-		public static final BigFloat NEGATIVE_INFINITY = new SpecialBigFloat(TYPE.NEGATIVE_INFINITY);
-		private static final BigFloat.Context THIS_CONTEXT = new Context(MathContext.DECIMAL64);
-
-		private final TYPE type;
-
-		private SpecialBigFloat(TYPE type) {
-			//we don't need it because
-			//all method has been override
-			super(null, null);
-			this.type = type;
-		}
-
-		private static BigFloat valueOf(TYPE type) {
-			switch (type) {
-				case POSITIVE_INFINITY:
-					return POSITIVE_INFINITY;
-				case NEGATIVE_INFINITY:
-					return NEGATIVE_INFINITY;
-				case NAN:
-					return NAN;
-				default:
-					return UNKNOWN;
-			}
-		}
-
-		private static void checkUnsupported(BigFloat... bigFloats) {
-			for (BigFloat val : bigFloats)
-				if (val.isSpecial())
-					throw new NumberFormatException(val.toString());
-		}
-
-		public static BigFloat ofDouble(double d) {
-			if (Double.isNaN(d))
-				return BigFloat.NAN;
-			else if (d == Double.POSITIVE_INFINITY)
-				return BigFloat.POSITIVE_INFINITY;
-			else if (d == Double.NEGATIVE_INFINITY)
-				return BigFloat.NEGATIVE_INFINITY;
-			else return new BigFloat(BigDecimal.valueOf(d), new Context(MathContext.DECIMAL64));
-		}
-
-		private static void throwNan() {
-			throw new NumberFormatException("Not A Number");
-		}
-
-		private void checkNAN() {
-			if (type == TYPE.NAN)
-				throw new NumberFormatException("Not A Number");
-		}
-
-		private void unsupported() {
-			throw new NumberFormatException(this.toString());
-		}
-
-		@Override
-		public boolean isSpecial() {
-			return true;
-		}
-
-		@Override
-		public TYPE specialType() {
-			return type;
-		}
-
-		@Override
-		public BigFloat add(BigFloat x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat add(BigDecimal x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat add(int x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat add(long x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat add(double x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat subtract(BigFloat x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat subtract(BigDecimal x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat subtract(int x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat subtract(long x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat subtract(double x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat multiply(BigFloat x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat multiply(BigDecimal x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat multiply(int x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat multiply(long x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat multiply(double x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat divide(BigFloat x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat divide(BigDecimal x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat divide(int x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat divide(long x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat divide(double x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat remainder(BigFloat x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat remainder(BigDecimal x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat remainder(int x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat remainder(long x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat remainder(double x) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat pow(BigFloat y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat pow(BigDecimal y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat pow(int y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat pow(long y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat pow(double y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat root(BigFloat y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat root(BigDecimal y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat root(int y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat root(long y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat root(double y) {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hashCode(toDouble());
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj instanceof BigFloat)
-				return ((BigFloat) obj).isSpecial() && ((BigFloat) obj).specialType() == this.type;
-			return false;
-		}
-
-		@Override
-		public int signum() {
-			switch (type) {
-				case POSITIVE_INFINITY:
-					return 1;
-				case NEGATIVE_INFINITY:
-					return -1;
-				default:
-					return 0;
-			}
-		}
-
-		@Override
-		public boolean isNegative() {
-			return signum() == -1;
-		}
-
-		@Override
-		public boolean isZero() {
-			return false;//nan or infinity is not a zero
-		}
-
-		@Override
-		public boolean isPositive() {
-			return signum() == 1;
-		}
-
-		@Override
-		public int compareTo(BigFloat other) {
-			checkNAN();
-			return TYPE.compare(type, other.specialType());
-		}
-
-		@Override
-		public boolean isIntValue() {
-			return false;//nope
-		}
-
-		@Override
-		public boolean isDoubleValue() {
-			return false;//nope
-		}
-
-		@Override
-		public BigFloat getMantissa() {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat getExponent() {
-			checkNAN();
-			return this;
-		}
-
-		@Override
-		public BigFloat getIntegralPart() {
-			unsupported();
-			return null;
-		}
-
-		@Override
-		public BigFloat getFractionalPart() {
-			unsupported();
-			return null;
-		}
-
-		@Override
-		public Context getContext() {
-			checkNAN();
-			unsupported();
-			return THIS_CONTEXT;
-		}
-
-		@Override
-		public BigDecimal toBigDecimal() {
-			unsupported();
-			return null;//nope
-		}
-
-		@Override
-		public double toDouble() {
-			switch (type) {
-				case POSITIVE_INFINITY:
-					return Double.POSITIVE_INFINITY;
-				case NEGATIVE_INFINITY:
-					return Double.NEGATIVE_INFINITY;
-				default:
-					return Double.NaN;
-			}
-		}
-
-		@Override
-		public long toLong() {
-			checkNAN();
-			return (long) toDouble();
-		}
-
-		@Override
-		public int toInt() {
-			checkNAN();
-			return (int) toDouble();
-		}
-
-		@Override
-		public String toString() {
-			switch (type) {
-				case NAN:
-					return "NAN";
-				case NEGATIVE_INFINITY:
-					return "-INF";
-				case POSITIVE_INFINITY:
-					return "+INF";
-				default:
-					return "UNKNOWN";
-			}
-		}
-
-		public enum TYPE {
-			NAN,
-			POSITIVE_INFINITY,
-			NEGATIVE_INFINITY,
-			/**
-			 * Unknown type mean it's normal value
-			 */
-			UNKNOWN;
-
-			public static int compare(TYPE a, TYPE b) {
-				//NAN less than everything
-				if (a == NAN)
-					return -1;
-				if (b == NAN)
-					return 1;
-				if (a == POSITIVE_INFINITY)
-					if (b == POSITIVE_INFINITY)
-						return 0;
-					else if (b == NEGATIVE_INFINITY)
-						return 1;
-					else if (b == UNKNOWN)
-						return 1;
-				if (a == NEGATIVE_INFINITY)
-					if (b == NEGATIVE_INFINITY)
-						return 0;
-					else if (b == POSITIVE_INFINITY)
-						return -1;
-					else if (b == UNKNOWN)
-						return -1;
-				if (a == UNKNOWN)
-					if (b == NEGATIVE_INFINITY)
-						return -1;
-					else if (b == POSITIVE_INFINITY)
-						return 1;
-				return 0;
-			}
-		}
 	}
 }

--- a/ch.obermuhlner.math.big/src/test/java/ch/obermuhlner/math/big/BigFloatTest.java
+++ b/ch.obermuhlner.math.big/src/test/java/ch/obermuhlner/math/big/BigFloatTest.java
@@ -1,15 +1,13 @@
 package ch.obermuhlner.math.big;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import ch.obermuhlner.math.big.BigFloat.*;
+import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
 
-import org.junit.Test;
-
-import ch.obermuhlner.math.big.BigFloat.Context;
 import static ch.obermuhlner.math.big.BigFloat.*;
+import static org.junit.Assert.*;
 
 public class BigFloatTest {
 
@@ -17,13 +15,13 @@ public class BigFloatTest {
 	public void testContext() {
 		MathContext mathContext = new MathContext(20);
 		Context context = context(mathContext);
-		
+
 		assertEquals(mathContext, context.getMathContext());
 		assertEquals(mathContext.getPrecision(), context.getPrecision());
 		assertEquals(mathContext.getRoundingMode(), context.getRoundingMode());
-		
+
 		assertEquals(1000, context(1000).getPrecision());
-		
+
 		assertEquals(context, context(mathContext));
 		assertEquals(context.hashCode(), context(mathContext).hashCode());
 		assertEquals(context.toString(), context(mathContext).toString());
@@ -31,7 +29,7 @@ public class BigFloatTest {
 		assertNotEquals(context, null);
 		assertNotEquals(context, "string");
 	}
-	
+
 	@Test
 	public void testValueOf() {
 		Context context = context(MathContext.DECIMAL32);
@@ -39,7 +37,7 @@ public class BigFloatTest {
 		assertEquals(0, BigDecimal.ONE.compareTo(context.valueOf(1).toBigDecimal()));
 		assertEquals(0, BigDecimal.ONE.compareTo(context.valueOf(1L).toBigDecimal()));
 		assertEquals(0, BigDecimal.ONE.compareTo(context.valueOf(1.0).toBigDecimal()));
-		
+
 		Context anotherContext = context(MathContext.DECIMAL64);
 		assertEquals(0, BigDecimal.ONE.compareTo(context.valueOf(anotherContext.valueOf(1.0)).toBigDecimal()));
 		assertEquals(0, BigDecimal.ONE.compareTo(anotherContext.valueOf(context.valueOf(1.0)).toBigDecimal()));
@@ -47,16 +45,18 @@ public class BigFloatTest {
 		assertEquals(context, context.valueOf(anotherContext.valueOf(1.0)).getContext());
 		assertEquals(anotherContext, anotherContext.valueOf(context.valueOf(1.0)).getContext());
 	}
-	
+
 	@Test
 	public void testValueOfRounding() {
 		Context context = context(new MathContext(3));
-		
+
 		assertEquals(0, BigDecimal.valueOf(123000).compareTo(context.valueOf(123456).toBigDecimal()));
 		assertEquals(0, BigDecimal.valueOf(123000).compareTo(context.valueOf(123456L).toBigDecimal()));
 		assertEquals(0, BigDecimal.valueOf(123000).compareTo(context.valueOf(123456.0).toBigDecimal()));
-		assertEquals(0, BigDecimal.valueOf(123000).compareTo(context.valueOf(BigDecimal.valueOf(123456)).toBigDecimal()));
-		assertEquals(0, BigDecimal.valueOf(123000).compareTo(context.valueOf(context(20).valueOf(123456)).toBigDecimal()));
+		assertEquals(0,
+				BigDecimal.valueOf(123000).compareTo(context.valueOf(BigDecimal.valueOf(123456)).toBigDecimal()));
+		assertEquals(0,
+				BigDecimal.valueOf(123000).compareTo(context.valueOf(context(20).valueOf(123456)).toBigDecimal()));
 	}
 
 	@Test
@@ -64,13 +64,13 @@ public class BigFloatTest {
 		Context context = context(MathContext.DECIMAL64);
 		assertEquals(3.14, context.valueOf(3.14).toDouble(), 0.0);
 	}
-	
+
 	@Test
 	public void testToLong() {
 		Context context = context(MathContext.DECIMAL64);
 		assertEquals(1234L, context.valueOf(1234).toLong());
 	}
-	
+
 	@Test
 	public void testToInt() {
 		Context context = context(MathContext.DECIMAL64);
@@ -107,7 +107,7 @@ public class BigFloatTest {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(context.valueOf(1.23), context.valueOf(1.23E99).getMantissa());
 	}
-	
+
 	@Test
 	public void testGetExponent() {
 		Context context = context(MathContext.DECIMAL32);
@@ -129,7 +129,7 @@ public class BigFloatTest {
 	@Test
 	public void testEquals() {
 		Context context = context(MathContext.DECIMAL32);
-		
+
 		assertNotEquals(context.valueOf(1234), null);
 		assertNotEquals(context.valueOf(1234), "string");
 
@@ -139,14 +139,14 @@ public class BigFloatTest {
 		assertEquals(context.valueOf(1234), context.valueOf(1234));
 		assertNotEquals(context.valueOf(1234), context.valueOf(9999));
 		assertNotEquals(context.valueOf(9999), context.valueOf(1234));
-		
+
 		Context equalContext = context(MathContext.DECIMAL32);
 		assertEquals(context, equalContext);
 		assertEquals(context.valueOf(1234), equalContext.valueOf(1234));
 		assertEquals(context.valueOf(1234), equalContext.valueOf(1234.0));
 		assertEquals(context.valueOf(1234), equalContext.valueOf("1234.0000"));
 		assertEquals(equalContext.valueOf(1234), context.valueOf(1234));
-		
+
 		Context anotherContext = context(MathContext.DECIMAL64);
 		assertNotEquals(context, anotherContext);
 		assertEquals(context.valueOf(1234), anotherContext.valueOf(1234));
@@ -179,13 +179,13 @@ public class BigFloatTest {
 		assertEquals("1.234", context.valueOf(1.234).toString());
 		assertEquals("-1.234", context.valueOf(-1.234).toString());
 	}
-	
+
 	@Test
 	public void testPi() {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(BigDecimalMath.pi(context.getMathContext()), context.pi().toBigDecimal());
 	}
-	
+
 	@Test
 	public void testE() {
 		Context context = context(MathContext.DECIMAL32);
@@ -204,7 +204,7 @@ public class BigFloatTest {
 		assertEquals(1, context.valueOf("1E999").signum());
 		assertEquals(1, context.valueOf("1E-999").signum());
 	}
-	
+
 	@Test
 	public void testIsNegative() {
 		Context context = context(MathContext.DECIMAL32);
@@ -217,7 +217,7 @@ public class BigFloatTest {
 		assertEquals(false, context.valueOf("1E999").isNegative());
 		assertEquals(false, context.valueOf("1E-999").isNegative());
 	}
-	
+
 	@Test
 	public void testIsZero() {
 		Context context = context(MathContext.DECIMAL32);
@@ -230,7 +230,7 @@ public class BigFloatTest {
 		assertEquals(false, context.valueOf("1E999").isZero());
 		assertEquals(false, context.valueOf("1E-999").isZero());
 	}
-	
+
 	@Test
 	public void testIsPositive() {
 		Context context = context(MathContext.DECIMAL32);
@@ -243,14 +243,14 @@ public class BigFloatTest {
 		assertEquals(true, context.valueOf("1E999").isPositive());
 		assertEquals(true, context.valueOf("1E-999").isPositive());
 	}
-	
+
 	@Test
 	public void testIsEqual() {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(true, context.valueOf(5).isEqual(context.valueOf(5)));
 		assertEquals(true, context.valueOf(5).isEqual(context.valueOf(5.0)));
 		assertEquals(false, context.valueOf(1).isEqual(context.valueOf(5)));
-	}	
+	}
 
 	@Test
 	public void testIsLessThan() {
@@ -258,7 +258,7 @@ public class BigFloatTest {
 		assertEquals(true, context.valueOf(1).isLessThan(context.valueOf(5)));
 		assertEquals(false, context.valueOf(5).isLessThan(context.valueOf(1)));
 		assertEquals(false, context.valueOf(5).isLessThan(context.valueOf(5)));
-	}	
+	}
 
 	@Test
 	public void testIsLessThanOrEqual() {
@@ -266,7 +266,7 @@ public class BigFloatTest {
 		assertEquals(true, context.valueOf(1).isLessThanOrEqual(context.valueOf(5)));
 		assertEquals(false, context.valueOf(5).isLessThanOrEqual(context.valueOf(1)));
 		assertEquals(true, context.valueOf(5).isLessThanOrEqual(context.valueOf(5)));
-	}	
+	}
 
 	@Test
 	public void testIsGreaterThan() {
@@ -274,7 +274,7 @@ public class BigFloatTest {
 		assertEquals(true, context.valueOf(5).isGreaterThan(context.valueOf(1)));
 		assertEquals(false, context.valueOf(1).isGreaterThan(context.valueOf(5)));
 		assertEquals(false, context.valueOf(5).isGreaterThan(context.valueOf(5)));
-	}	
+	}
 
 	@Test
 	public void testIsGreaterThanOrEqual() {
@@ -282,7 +282,7 @@ public class BigFloatTest {
 		assertEquals(true, context.valueOf(5).isGreaterThanOrEqual(context.valueOf(1)));
 		assertEquals(false, context.valueOf(1).isGreaterThanOrEqual(context.valueOf(5)));
 		assertEquals(true, context.valueOf(5).isGreaterThanOrEqual(context.valueOf(5)));
-	}	
+	}
 
 	@Test
 	public void testCompareTo() {
@@ -291,7 +291,7 @@ public class BigFloatTest {
 		assertEquals(-1, context.valueOf(1).compareTo(context.valueOf(5)));
 		assertEquals(0, context.valueOf(5).compareTo(context.valueOf(5)));
 	}
-	
+
 	@Test
 	public void testAdd() {
 		Context context = context(MathContext.DECIMAL32);
@@ -306,13 +306,13 @@ public class BigFloatTest {
 	public void testAddBigFloat() {
 		Context smallContext = context(MathContext.DECIMAL32);
 		Context largeContext = context(MathContext.DECIMAL64);
-		
+
 		assertEquals(smallContext, smallContext.valueOf(2).add(smallContext.valueOf(3)).getContext());
 		assertEquals(largeContext, smallContext.valueOf(2).add(largeContext.valueOf(3)).getContext());
 		assertEquals(largeContext, largeContext.valueOf(2).add(smallContext.valueOf(3)).getContext());
 		assertEquals(largeContext, largeContext.valueOf(2).add(largeContext.valueOf(3)).getContext());
 	}
-	
+
 	@Test
 	public void testSubtract() {
 		Context context = context(MathContext.DECIMAL32);
@@ -378,155 +378,180 @@ public class BigFloatTest {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(context.valueOf(720), context.factorial(6));
 	}
-	
+
 	@Test
 	public void testLog() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(log(context.valueOf(3)).toBigDecimal(), BigDecimalMath.log(BigDecimal.valueOf(3), MathContext.DECIMAL32));
+		assertEquals(log(context.valueOf(3)).toBigDecimal(),
+				BigDecimalMath.log(BigDecimal.valueOf(3), MathContext.DECIMAL32));
 	}
-	
+
 	@Test
 	public void testLog2() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(log2(context.valueOf(3)).toBigDecimal(), BigDecimalMath.log2(BigDecimal.valueOf(3), MathContext.DECIMAL32));
+		assertEquals(log2(context.valueOf(3)).toBigDecimal(),
+				BigDecimalMath.log2(BigDecimal.valueOf(3), MathContext.DECIMAL32));
 	}
-	
+
 	@Test
 	public void testLog10() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(log10(context.valueOf(3)).toBigDecimal(), BigDecimalMath.log10(BigDecimal.valueOf(3), MathContext.DECIMAL32));
+		assertEquals(log10(context.valueOf(3)).toBigDecimal(),
+				BigDecimalMath.log10(BigDecimal.valueOf(3), MathContext.DECIMAL32));
 	}
-	
+
 	@Test
 	public void testExp() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(exp(context.valueOf(3)).toBigDecimal(), BigDecimalMath.exp(BigDecimal.valueOf(3), MathContext.DECIMAL32));
+		assertEquals(exp(context.valueOf(3)).toBigDecimal(),
+				BigDecimalMath.exp(BigDecimal.valueOf(3), MathContext.DECIMAL32));
 	}
-	
+
 	@Test
 	public void testSqrt() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.sqrt(BigDecimal.valueOf(3), MathContext.DECIMAL32), sqrt(context.valueOf(3)).toBigDecimal());
+		assertEquals(BigDecimalMath.sqrt(BigDecimal.valueOf(3), MathContext.DECIMAL32),
+				sqrt(context.valueOf(3)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testPow2() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.pow(BigDecimal.valueOf(2), BigDecimal.valueOf(3), MathContext.DECIMAL32), context.valueOf(2).pow(3).toBigDecimal());
+		assertEquals(BigDecimalMath.pow(BigDecimal.valueOf(2), BigDecimal.valueOf(3), MathContext.DECIMAL32),
+				context.valueOf(2).pow(3).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testRoot2() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.root(BigDecimal.valueOf(8), BigDecimal.valueOf(3), MathContext.DECIMAL32), context.valueOf(8).root(3).toBigDecimal());
+		assertEquals(BigDecimalMath.root(BigDecimal.valueOf(8), BigDecimal.valueOf(3), MathContext.DECIMAL32),
+				context.valueOf(8).root(3).toBigDecimal());
 	}
 
 	@Test
 	public void testPowStatic() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.pow(BigDecimal.valueOf(2), BigDecimal.valueOf(3), MathContext.DECIMAL32), pow(context.valueOf(2), context.valueOf(3)).toBigDecimal());
+		assertEquals(BigDecimalMath.pow(BigDecimal.valueOf(2), BigDecimal.valueOf(3), MathContext.DECIMAL32),
+				pow(context.valueOf(2), context.valueOf(3)).toBigDecimal());
 	}
 
 	@Test
 	public void testRootStatic() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.root(BigDecimal.valueOf(8), BigDecimal.valueOf(3), MathContext.DECIMAL32), root(context.valueOf(8), context.valueOf(3)).toBigDecimal());
+		assertEquals(BigDecimalMath.root(BigDecimal.valueOf(8), BigDecimal.valueOf(3), MathContext.DECIMAL32),
+				root(context.valueOf(8), context.valueOf(3)).toBigDecimal());
 	}
 
 	@Test
 	public void testSin() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.sin(BigDecimal.valueOf(0), MathContext.DECIMAL32), sin(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.sin(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				sin(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testCos() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.cos(BigDecimal.valueOf(0), MathContext.DECIMAL32), cos(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.cos(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				cos(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testTan() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.tan(BigDecimal.valueOf(0), MathContext.DECIMAL32), tan(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.tan(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				tan(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testCot() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.cot(BigDecimal.valueOf(1), MathContext.DECIMAL32), cot(context.valueOf(1)).toBigDecimal());
+		assertEquals(BigDecimalMath.cot(BigDecimal.valueOf(1), MathContext.DECIMAL32),
+				cot(context.valueOf(1)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAsin() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.asin(BigDecimal.valueOf(0), MathContext.DECIMAL32), asin(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.asin(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				asin(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAcos() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.acos(BigDecimal.valueOf(0), MathContext.DECIMAL32), acos(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.acos(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				acos(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAtan() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.atan(BigDecimal.valueOf(0), MathContext.DECIMAL32), atan(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.atan(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				atan(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAcot() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.acot(BigDecimal.valueOf(0), MathContext.DECIMAL32), acot(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.acot(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				acot(context.valueOf(0)).toBigDecimal());
 	}
 
 	@Test
 	public void testSinh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.sinh(BigDecimal.valueOf(0), MathContext.DECIMAL32), sinh(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.sinh(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				sinh(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testCosh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.cosh(BigDecimal.valueOf(0), MathContext.DECIMAL32), cosh(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.cosh(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				cosh(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testCoth() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.coth(BigDecimal.valueOf(1.1), MathContext.DECIMAL32), coth(context.valueOf(1.1)).toBigDecimal());
+		assertEquals(BigDecimalMath.coth(BigDecimal.valueOf(1.1), MathContext.DECIMAL32),
+				coth(context.valueOf(1.1)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testTanh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.tanh(BigDecimal.valueOf(0), MathContext.DECIMAL32), tanh(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.tanh(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				tanh(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAsinh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.asinh(BigDecimal.valueOf(0), MathContext.DECIMAL32), asinh(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.asinh(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				asinh(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAcosh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.acosh(BigDecimal.valueOf(1.1), MathContext.DECIMAL32), acosh(context.valueOf(1.1)).toBigDecimal());
+		assertEquals(BigDecimalMath.acosh(BigDecimal.valueOf(1.1), MathContext.DECIMAL32),
+				acosh(context.valueOf(1.1)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAtanh() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.atanh(BigDecimal.valueOf(0), MathContext.DECIMAL32), atanh(context.valueOf(0)).toBigDecimal());
+		assertEquals(BigDecimalMath.atanh(BigDecimal.valueOf(0), MathContext.DECIMAL32),
+				atanh(context.valueOf(0)).toBigDecimal());
 	}
-	
+
 	@Test
 	public void testAcoth() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(BigDecimalMath.acoth(BigDecimal.valueOf(1.1), MathContext.DECIMAL32), acoth(context.valueOf(1.1)).toBigDecimal());
+		assertEquals(BigDecimalMath.acoth(BigDecimal.valueOf(1.1), MathContext.DECIMAL32),
+				acoth(context.valueOf(1.1)).toBigDecimal());
 	}
 
 	@Test
@@ -550,7 +575,7 @@ public class BigFloatTest {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(context.valueOf(9), max(context.valueOf(9), context.valueOf(2)));
 		assertEquals(context.valueOf(9), max(context.valueOf(2), context.valueOf(9)));
-		
+
 		assertEquals(context.valueOf(9), max(context.valueOf(2), context.valueOf(9), context.valueOf(3)));
 		assertEquals(context.valueOf(9), max(context.valueOf(9), context.valueOf(2), context.valueOf(3)));
 	}
@@ -560,20 +585,27 @@ public class BigFloatTest {
 		Context context = context(MathContext.DECIMAL32);
 		assertEquals(context.valueOf(1), min(context.valueOf(1), context.valueOf(2)));
 		assertEquals(context.valueOf(1), min(context.valueOf(2), context.valueOf(1)));
-		
+
 		assertEquals(context.valueOf(1), min(context.valueOf(2), context.valueOf(1), context.valueOf(3)));
 		assertEquals(context.valueOf(1), min(context.valueOf(1), context.valueOf(2), context.valueOf(3)));
 	}
 
+	@SuppressWarnings("SimplifiableJUnitAssertion")
 	@Test
-	public void testSpecial(){
+	public void testSpecial() {
 		Context context = context(MathContext.DECIMAL32);
-		assertEquals(NAN,context.valueOf(Double.NaN));
-		assertEquals(POSITIVE_INFINITY,context.valueOf(Double.POSITIVE_INFINITY));
-		assertEquals(NEGATIVE_INFINITY,context.valueOf(Double.NEGATIVE_INFINITY));
+		assertSame(NaN, context.valueOf(Double.NaN));
+		assertSame(POSITIVE_INFINITY, context.valueOf(Double.POSITIVE_INFINITY));
+		assertSame(NEGATIVE_INFINITY, context.valueOf(Double.NEGATIVE_INFINITY));
 
-		assertEquals((Double)NAN.toDouble(),(Double)Double.NaN);
-		assertEquals((Double)POSITIVE_INFINITY.toDouble(),(Double)Double.POSITIVE_INFINITY);
-		assertEquals((Double)NEGATIVE_INFINITY.toDouble(),(Double)Double.NEGATIVE_INFINITY);
+		//Double.NaN equals nothing even itself
+		assertTrue(Double.isNaN(NaN.toDouble()));
+		assertTrue(Double.isInfinite(POSITIVE_INFINITY.toDouble()));
+		assertTrue(Double.isInfinite(NEGATIVE_INFINITY.toDouble()));
+
+		//it's final so it can be with ==
+		assertTrue(NEGATIVE_ONE.divide(ZERO) == NEGATIVE_INFINITY);
+		assertTrue(ZERO.divide(ZERO) == NaN);
+		assertTrue(ONE.divide(ZERO) == POSITIVE_INFINITY);
 	}
 }

--- a/ch.obermuhlner.math.big/src/test/java/ch/obermuhlner/math/big/BigFloatTest.java
+++ b/ch.obermuhlner.math.big/src/test/java/ch/obermuhlner/math/big/BigFloatTest.java
@@ -564,4 +564,16 @@ public class BigFloatTest {
 		assertEquals(context.valueOf(1), min(context.valueOf(2), context.valueOf(1), context.valueOf(3)));
 		assertEquals(context.valueOf(1), min(context.valueOf(1), context.valueOf(2), context.valueOf(3)));
 	}
+
+	@Test
+	public void testSpecial(){
+		Context context = context(MathContext.DECIMAL32);
+		assertEquals(NAN,context.valueOf(Double.NaN));
+		assertEquals(POSITIVE_INFINITY,context.valueOf(Double.POSITIVE_INFINITY));
+		assertEquals(NEGATIVE_INFINITY,context.valueOf(Double.NEGATIVE_INFINITY));
+
+		assertEquals((Double)NAN.toDouble(),(Double)Double.NaN);
+		assertEquals((Double)POSITIVE_INFINITY.toDouble(),(Double)Double.POSITIVE_INFINITY);
+		assertEquals((Double)NEGATIVE_INFINITY.toDouble(),(Double)Double.NEGATIVE_INFINITY);
+	}
 }


### PR DESCRIPTION
add `NAN`, `+INF`, `-INF` into `BigFloat` as a special type. all of this can't be calculated if we call arithmetic function from `NAN` it will `throw NumberFormatException("Not A Number")` but if we call arithmetic 
 function from `INFINITY` will return itself like `+INF + 1 = +INF` but `1 + +INF` is not implemented and I'll implement it later.

declared field
```
public static final BigFloat NAN;
public static final BigFloat POSITIVE_INFINITY;
public static final BigFloat NEGATIVE_INFINITY;

and `SpecialBigFloat.TYPE.*` is enum so they can be a static import
```
all value can parse via double like
```
Context context = context(MathContext.DECIMAL32);
NAN = context.valueOf(Double.NAN);
POS_INF = context.valueOf(Double.POSITIVE_INFINITY);
NEG_INF = context.valueOf(Double.NEGATIVE_INFINITY);
```
Fixes #4 implemented

Fixes #8 added `BigFloat.isNaN()` and `BigFloat.isInfinity()`