### PR TITLE
fix gamma(x) failing for integer x < 0 in BigComplexMath.

### DIFF
--- a/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigComplexMath.java
+++ b/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigComplexMath.java
@@ -97,7 +97,7 @@ public class BigComplexMath {
 	 * @see #gamma(BigComplex, MathContext)
 	 */
 	public static BigComplex factorial(BigComplex x, MathContext mathContext) {
-		if (x.isReal() && BigDecimalMath.isIntValue(x.re)) {
+		if (x.isReal() && BigDecimalMath.isIntValue(x.re) && x.re.intValueExact() > 0) {
 			return BigComplex.valueOf(BigDecimalMath.factorial(x.re.intValueExact()).round(mathContext));
 		}
 


### PR DESCRIPTION
Could be useful to provide an extended domain of gamma(z)